### PR TITLE
feat: Implement auth layout, page, and styles

### DIFF
--- a/workout-app/src/app.css
+++ b/workout-app/src/app.css
@@ -1,0 +1,209 @@
+/* src/app.css */
+:root {
+	--green: #065f46;
+	--yellow: #ffd60a;
+	--bg: #0b0f0c;
+	--card: #111814;
+	--text: #e6e6e6;
+	--text-muted: #b7c0bb;
+	--border-color: #173f2e;
+	--error: #ef4444;
+	--transition: 150ms ease;
+}
+
+* {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+body {
+	font-family:
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		sans-serif;
+	background-color: var(--bg);
+	color: var(--text);
+	min-height: 100vh;
+	line-height: 1.5;
+}
+
+a {
+	color: inherit;
+}
+
+.app-container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-height: 100vh;
+	padding: 20px;
+}
+
+.auth-page {
+	width: 100%;
+	max-width: 400px;
+}
+
+.auth-card {
+	background-color: var(--card);
+	border: 1px solid var(--border-color);
+	border-radius: 16px;
+	padding: 2rem;
+	text-align: center;
+	box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.auth-card h1 {
+	color: var(--yellow);
+	margin-bottom: 0.5rem;
+	font-size: 1.75rem;
+}
+
+.auth-card p {
+	color: var(--text-muted);
+	margin-bottom: 1.5rem;
+	font-size: 0.95rem;
+}
+
+.auth-card strong {
+	color: var(--text);
+}
+
+form {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.form-group {
+	text-align: left;
+	margin-bottom: 1rem;
+}
+
+.form-group label {
+	display: block;
+	margin-bottom: 0.5rem;
+	font-size: 0.9rem;
+	color: var(--text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.form-group input {
+	width: 100%;
+	background-color: var(--bg);
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	color: var(--text);
+	padding: 0.75rem;
+	font-size: 1rem;
+	transition:
+		box-shadow var(--transition),
+		outline var(--transition),
+		border-color var(--transition);
+}
+
+.form-group input::placeholder {
+	color: rgba(230, 230, 230, 0.5);
+}
+
+.form-group input:focus {
+	outline: 2px solid var(--yellow);
+	border-color: transparent;
+	box-shadow: 0 0 0 4px rgba(255, 214, 10, 0.15);
+}
+
+.primary-btn,
+.secondary-btn {
+	display: inline-block;
+	width: 100%;
+	border-radius: 8px;
+	padding: 0.75rem 1rem;
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	margin-top: 1rem;
+	text-decoration: none;
+	transition:
+		transform var(--transition),
+		box-shadow var(--transition),
+		background-color var(--transition);
+}
+
+.primary-btn {
+	background-color: var(--green);
+	color: var(--yellow);
+	border: 1px solid #0f3a2a;
+	box-shadow: 0 10px 25px rgba(6, 95, 70, 0.35);
+}
+
+.primary-btn:hover,
+.primary-btn:focus-visible {
+	background-color: #0a7c5d;
+	transform: translateY(-2px);
+}
+
+.secondary-btn {
+	background: #0f1512;
+	color: #d7fde2;
+	border: 1px solid var(--border-color);
+}
+
+.secondary-btn:hover,
+.secondary-btn:focus-visible {
+	background: #15201a;
+	transform: translateY(-1px);
+}
+
+.link-btn {
+	background: none;
+	border: none;
+	color: var(--yellow);
+	text-decoration: underline;
+	cursor: pointer;
+	font-size: inherit;
+	padding: 0;
+	margin-left: 0.5rem;
+}
+
+.link-btn:hover,
+.link-btn:focus-visible {
+	color: #ffe169;
+}
+
+.error-message {
+	color: var(--error);
+	font-size: 0.9rem;
+	margin-bottom: 1rem;
+	text-align: center;
+}
+
+button:focus-visible,
+.link-btn:focus-visible,
+.primary-btn:focus-visible,
+.secondary-btn:focus-visible {
+	outline: 2px solid var(--yellow);
+	outline-offset: 2px;
+}
+
+button:disabled,
+.primary-btn:disabled,
+.secondary-btn:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+	transform: none;
+	box-shadow: none;
+}
+
+@media (max-width: 480px) {
+	.auth-card {
+		padding: 1.75rem 1.5rem;
+	}
+
+	.auth-card h1 {
+		font-size: 1.5rem;
+	}
+}

--- a/workout-app/src/lib/firebase.js
+++ b/workout-app/src/lib/firebase.js
@@ -1,17 +1,17 @@
 // src/lib/firebase.js
 
-import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
-  apiKey: "AIzaSyCDGQJNmkpycpMm-TfShvukxfGPgTgBoD8",
-  authDomain: "pencoedtre-circuits-app.firebaseapp.com",
-  projectId: "pencoedtre-circuits-app",
-  storageBucket: "pencoedtre-circuits-app.firebasestorage.app",
-  messagingSenderId: "776510815016",
-  appId: "1:776510815016:web:9c0a8b3b19f2f108302e1d"
+	apiKey: 'AIzaSyCDGQJNmkpycpMm-TfShvukxfGPgTgBoD8',
+	authDomain: 'pencoedtre-circuits-app.firebaseapp.com',
+	projectId: 'pencoedtre-circuits-app',
+	storageBucket: 'pencoedtre-circuits-app.firebasestorage.app',
+	messagingSenderId: '776510815016',
+	appId: '1:776510815016:web:9c0a8b3b19f2f108302e1d'
 };
 
 // Initialize Firebase

--- a/workout-app/src/lib/store.js
+++ b/workout-app/src/lib/store.js
@@ -1,6 +1,9 @@
 // src/lib/store.js
-
 import { writable } from 'svelte/store';
 
-export const user = writable(null); // Starts as null because no user is logged in
-export const loading = writable(true); // To track the initial auth check
+/**
+ * @typedef {{ email: string | null; uid: string } | null} AuthUser
+ */
+
+export const user = writable(/** @type {AuthUser} */ (null));
+export const loading = writable(true);

--- a/workout-app/src/routes/+layout.svelte
+++ b/workout-app/src/routes/+layout.svelte
@@ -1,11 +1,28 @@
-<script lang="ts">
-	import favicon from '$lib/assets/favicon.svg';
+<script>
+	import { onMount } from 'svelte';
+	import { auth } from '$lib/firebase';
+	import { onAuthStateChanged } from 'firebase/auth';
+	import { user, loading } from '$lib/store';
+	import '../app.css'; // Import our global styles
 
-	let { children } = $props();
+	onMount(() => {
+		const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+			if (firebaseUser) {
+				$user = { email: firebaseUser.email, uid: firebaseUser.uid };
+			} else {
+				$user = null;
+			}
+			$loading = false;
+		});
+
+		return () => unsubscribe();
+	});
 </script>
 
-<svelte:head>
-	<link rel="icon" href={favicon} />
-</svelte:head>
-
-{@render children?.()}
+<div class="app-container">
+	{#if $loading}
+		<p>Loading...</p>
+	{:else}
+		<slot />
+	{/if}
+</div>

--- a/workout-app/src/routes/+page.svelte
+++ b/workout-app/src/routes/+page.svelte
@@ -1,2 +1,78 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script>
+	import { resolve } from '$app/paths';
+	import { auth } from '$lib/firebase';
+	import {
+		createUserWithEmailAndPassword,
+		signInWithEmailAndPassword,
+		signOut
+	} from 'firebase/auth';
+	import { user } from '$lib/store';
+
+	let email = '';
+	let password = '';
+	let errorMessage = '';
+	let isNewUser = false;
+
+	async function handleSubmit() {
+		if (!email || !password) {
+			errorMessage = 'Email and password are required.';
+			return;
+		}
+		errorMessage = '';
+		try {
+			if (isNewUser) {
+				await createUserWithEmailAndPassword(auth, email, password);
+			} else {
+				await signInWithEmailAndPassword(auth, email, password);
+			}
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	async function handleSignOut() {
+		await signOut(auth);
+	}
+
+	const dashboardUrl = resolve(/** @type {any} */ ('/dashboard'));
+</script>
+
+<main class="auth-page">
+	{#if $user}
+		<div class="auth-card">
+			<h1>Welcome!</h1>
+			<p>You are signed in as: <strong>{$user?.email}</strong></p>
+			<button class="primary-btn" on:click={handleSignOut}>Sign Out</button>
+			<a href={dashboardUrl} class="secondary-btn">Go to Dashboard</a>
+		</div>
+	{:else}
+		<div class="auth-card">
+			<h1>{isNewUser ? 'Create Account' : 'Sign In'}</h1>
+			<p>
+				{isNewUser ? 'Already have an account?' : 'Need an account?'}
+				<button class="link-btn" on:click={() => (isNewUser = !isNewUser)}>
+					{isNewUser ? 'Sign In' : 'Sign Up'}
+				</button>
+			</p>
+
+			<form on:submit|preventDefault={handleSubmit}>
+				<div class="form-group">
+					<label for="email">Email</label>
+					<input id="email" type="email" bind:value={email} placeholder="you@email.com" />
+				</div>
+				<div class="form-group">
+					<label for="password">Password</label>
+					<input id="password" type="password" bind:value={password} placeholder="••••••" />
+				</div>
+
+				{#if errorMessage}
+					<p class="error-message">{errorMessage}</p>
+				{/if}
+
+				<button type="submit" class="primary-btn">
+					{isNewUser ? 'Create Account' : 'Sign In'}
+				</button>
+			</form>
+		</div>
+	{/if}
+</main>


### PR DESCRIPTION
## Summary
- wire the root layout to listen for Firebase auth state changes and expose loading state
- replace the default landing page with an email/password auth form and dashboard shortcut
- add global styling for the authentication views and tighten firebase/store typing helpers

## Testing
- npm run check
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b3908080832fac9c5e0f522e9e6c