### PR TITLE
Add protected dashboard page

### DIFF
--- a/workout-app/src/routes/dashboard/+layout.js
+++ b/workout-app/src/routes/dashboard/+layout.js
@@ -1,0 +1,14 @@
+// src/routes/dashboard/+layout.js
+import { user } from '$lib/store';
+import { get } from 'svelte/store';
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	// Get the current value of the user from the store
+	const currentUser = get(user);
+
+	// If there is no user logged in, redirect them to the home page
+	if (!currentUser) {
+		throw redirect(307, '/');
+	}
+}

--- a/workout-app/src/routes/dashboard/+page.svelte
+++ b/workout-app/src/routes/dashboard/+page.svelte
@@ -1,0 +1,32 @@
+<script>
+	import { user } from '$lib/store';
+	import { auth } from '$lib/firebase';
+	import { signOut } from 'firebase/auth';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+
+	async function handleSignOut() {
+		await signOut(auth);
+		// After signing out, redirect the user to the home page
+		goto(resolve('/'));
+	}
+</script>
+
+<div class="dashboard-card">
+	<h1>Dashboard</h1>
+	<p>Welcome, <strong>{$user?.email}</strong>!</p>
+	<p>This is a protected page. Only logged-in users can see this.</p>
+	<button class="primary-btn" on:click={handleSignOut}> Sign Out </button>
+</div>
+
+<style>
+	.dashboard-card {
+		background-color: var(--card);
+		border: 1px solid var(--border-color);
+		border-radius: 16px;
+		padding: 2rem;
+		text-align: center;
+		width: 100%;
+		max-width: 500px;
+	}
+</style>


### PR DESCRIPTION
## Summary
- add a dashboard layout guard that redirects unauthenticated users
- implement the dashboard page UI with a sign-out action for logged-in users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d30d10358c832f80f4260e3365a127