### PR TITLE
Add new timer page layout and fonts

### DIFF
--- a/workout-app/src/routes/+layout.svelte
+++ b/workout-app/src/routes/+layout.svelte
@@ -19,6 +19,15 @@
 	});
 </script>
 
+<svelte:head>
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;700&display=swap"
+		rel="stylesheet"
+	/>
+</svelte:head>
+
 <div class="app-container">
 	{#if $loading}
 		<p>Loading...</p>

--- a/workout-app/src/routes/timer/[id]/+page.svelte
+++ b/workout-app/src/routes/timer/[id]/+page.svelte
@@ -5,7 +5,7 @@
 	export let data;
 	const { workout } = data;
 
-	// --- Sound Imports & Functions (No Change) ---
+	// --- Sound Imports & Functions ---
 	let audioCtx = null;
 	function getCtx() {
 		return audioCtx || (audioCtx = new (window.AudioContext || window.webkitAudioContext)());
@@ -13,16 +13,16 @@
 	function tone(freq = 800, dur = 200, type = 'sine', gain = 0.25) {
 		try {
 			const ctx = getCtx();
-			const o = ctx.createOscillator();
-			const g = ctx.createGain();
-			o.type = type;
-			o.frequency.setValueAtTime(freq, ctx.currentTime);
-			o.connect(g);
-			g.connect(ctx.destination);
-			g.gain.setValueAtTime(gain, ctx.currentTime);
-			g.gain.exponentialRampToValueAtTime(1e-4, ctx.currentTime + dur / 1000);
-			o.start();
-			o.stop(ctx.currentTime + dur / 1000);
+			const oscillator = ctx.createOscillator();
+			const gainNode = ctx.createGain();
+			oscillator.type = type;
+			oscillator.frequency.setValueAtTime(freq, ctx.currentTime);
+			oscillator.connect(gainNode);
+			gainNode.connect(ctx.destination);
+			gainNode.gain.setValueAtTime(gain, ctx.currentTime);
+			gainNode.gain.exponentialRampToValueAtTime(1e-4, ctx.currentTime + dur / 1000);
+			oscillator.start();
+			oscillator.stop(ctx.currentTime + dur / 1000);
 		} catch (error) {
 			console.warn('Tone playback failed', error);
 		}
@@ -31,20 +31,20 @@
 		try {
 			const ctx = getCtx();
 			for (let i = 0; i < 2; i += 1) {
-				const g = ctx.createGain();
+				const gainNode = ctx.createGain();
 				const t0 = ctx.currentTime + i * 0.15;
-				g.connect(ctx.destination);
-				g.gain.setValueAtTime(1e-4, t0);
-				g.gain.linearRampToValueAtTime(i === 0 ? 0.85 : 0.7, t0 + 0.02);
-				g.gain.exponentialRampToValueAtTime(1e-4, t0 + 1.2);
+				gainNode.connect(ctx.destination);
+				gainNode.gain.setValueAtTime(1e-4, t0);
+				gainNode.gain.linearRampToValueAtTime(i === 0 ? 0.85 : 0.7, t0 + 0.02);
+				gainNode.gain.exponentialRampToValueAtTime(1e-4, t0 + 1.2);
 				const o1 = ctx.createOscillator();
 				const o2 = ctx.createOscillator();
 				o1.type = 'triangle';
 				o2.type = 'triangle';
 				o1.frequency.setValueAtTime(620, t0);
 				o2.frequency.setValueAtTime(930, t0);
-				o1.connect(g);
-				o2.connect(g);
+				o1.connect(gainNode);
+				o2.connect(gainNode);
 				o1.start(t0);
 				o2.start(t0);
 				o1.stop(t0 + 1.25);
@@ -55,11 +55,11 @@
 		}
 	}
 	function countBeep(n) {
-		const f = { 3: 520, 2: 680, 1: 940 };
-		tone(f[n] || 720, 180, 'sine', 0.35);
+		const freqMap = { 3: 520, 2: 680, 1: 940 };
+		tone(freqMap[n] || 720, 180, 'sine', 0.35);
 	}
 
-	// --- Session Setup & Timer State (No Change) ---
+	// --- Session Setup & Timer State ---
 	let isSetupVisible = true;
 	let sessionConfig = { work: 60, swap: 15, move: 15, rounds: 1 };
 	let state = {
@@ -74,17 +74,17 @@
 		lastCue: 0
 	};
 	let timerId = null;
+
+	// --- Staff Roster Logic ---
 	let totalStations = workout.exercises?.length ?? 0;
 	let stationAssignments = (workout.exercises ?? []).map(() => []);
 	let assignmentInputs = (workout.exercises ?? []).map(() => '');
-
-	// --- Logic & Functions (No Change) ---
 	function parseAssignments(value = '') {
 		return value
 			.split(/[\n,]/)
-			.map((c) => c.trim())
+			.map((code) => code.trim())
 			.filter(Boolean)
-			.map((c) => c.toUpperCase());
+			.map((code) => code.toUpperCase());
 	}
 	function commitAssignmentInput(index) {
 		const parsed = parseAssignments(assignmentInputs[index] ?? '');
@@ -97,6 +97,8 @@
 		);
 		assignmentInputs = stationAssignments.map((codes) => codes.join(', '));
 	}
+
+	// --- Svelte Reactive Statements ---
 	$: movesCompleted =
 		totalStations > 0 ? (state.currentRound - 1) * totalStations + state.currentStation : 0;
 	$: stationRoster = (workout.exercises ?? []).map((_, targetIndex) => {
@@ -110,20 +112,17 @@
 		});
 		return roster;
 	});
-	$: phaseMessage = (() => {
-		if (state.phaseIndex === 1) return 'Prepare to switch roles.';
-		if (state.phaseIndex === 3) return 'Move to your next station now.';
-		if (state.phaseIndex === 2) return 'Roles are now swapped!';
-		return '';
-	})();
 	$: progress =
 		state.duration > 0
 			? Math.min(100, Math.max(0, ((state.duration - state.remaining) / state.duration) * 100))
 			: 0;
+
+	// --- Timer Logic ---
 	function advancePhase() {
 		if (!totalStations) return;
 		state.lastCue = 0;
 		const nextPhaseIndex = state.phaseIndex + 1;
+
 		if (workout.mode === 'Partner' && workout.type === 'Circuit') {
 			if (nextPhaseIndex === 0) {
 				state.phaseIndex = 0;
@@ -146,10 +145,10 @@
 				state.remaining = state.duration = sessionConfig.move;
 				tone(420, 160);
 			} else {
-				state.currentStation++;
+				state.currentStation += 1;
 				if (state.currentStation >= totalStations) {
 					state.currentStation = 0;
-					state.currentRound++;
+					state.currentRound += 1;
 					if (state.currentRound > sessionConfig.rounds) {
 						workoutComplete();
 						return;
@@ -161,7 +160,7 @@
 				whistleBell();
 			}
 		} else {
-			state.currentStation++;
+			state.currentStation += 1;
 			if (state.currentStation >= totalStations) {
 				workoutComplete();
 				return;
@@ -173,10 +172,10 @@
 	}
 	function tick() {
 		state.remaining -= 0.1;
-		const secs = Math.ceil(state.remaining);
-		if (secs <= 3 && secs >= 1 && secs !== state.lastCue) {
-			state.lastCue = secs;
-			countBeep(secs);
+		const secondsRemaining = Math.ceil(state.remaining);
+		if (secondsRemaining <= 3 && secondsRemaining >= 1 && secondsRemaining !== state.lastCue) {
+			state.lastCue = secondsRemaining;
+			countBeep(secondsRemaining);
 		}
 		if (state.remaining <= 0) {
 			advancePhase();
@@ -228,12 +227,13 @@
 		commitAllAssignments();
 		isSetupVisible = false;
 	}
-	function formatTime(s) {
-		const secs = Math.max(0, Math.ceil(s));
-		return (
-			String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0')
-		);
+	function formatTime(value) {
+		const seconds = Math.max(0, Math.ceil(value));
+		const minutes = String(Math.floor(seconds / 60)).padStart(2, '0');
+		const remainder = String(seconds % 60).padStart(2, '0');
+		return `${minutes}:${remainder}`;
 	}
+
 	onDestroy(() => clearInterval(timerId));
 </script>
 
@@ -244,36 +244,20 @@
 			<p>Configure timer intervals and assign staff to their starting stations.</p>
 			<div class="setup-form">
 				<div class="form-group">
-					<label for="work">Work (s)</label><input
-						id="work"
-						type="number"
-						min="0"
-						bind:value={sessionConfig.work}
-					/>
+					<label for="work">Work (s)</label>
+					<input id="work" type="number" min="0" bind:value={sessionConfig.work} />
 				</div>
 				<div class="form-group">
-					<label for="swap">Swap (s)</label><input
-						id="swap"
-						type="number"
-						min="0"
-						bind:value={sessionConfig.swap}
-					/>
+					<label for="swap">Swap (s)</label>
+					<input id="swap" type="number" min="0" bind:value={sessionConfig.swap} />
 				</div>
 				<div class="form-group">
-					<label for="move">Move/Rest (s)</label><input
-						id="move"
-						type="number"
-						min="0"
-						bind:value={sessionConfig.move}
-					/>
+					<label for="move">Move/Rest (s)</label>
+					<input id="move" type="number" min="0" bind:value={sessionConfig.move} />
 				</div>
 				<div class="form-group">
-					<label for="rounds">Rounds</label><input
-						id="rounds"
-						type="number"
-						min="1"
-						bind:value={sessionConfig.rounds}
-					/>
+					<label for="rounds">Rounds</label>
+					<input id="rounds" type="number" min="1" bind:value={sessionConfig.rounds} />
 				</div>
 			</div>
 			<div class="assignment-setup">
@@ -304,109 +288,124 @@
 {/if}
 
 <div class="timer-wrapper" class:blur={isSetupVisible}>
-	<div class="timer-layout">
-		<section class="station-overview">
-			<div class="station-overview__header">
-				<h2>Stations</h2>
-				<div class="station-overview__meta">
-					<span>{totalStations} Stations</span>
-					<button class="ghost-button" on:click={openSetup}>Adjust Setup</button>
-				</div>
-			</div>
-			<div class="station-strip">
-				{#each workout.exercises as station, i (i)}
-					<article class="station-card" class:current={i === state.currentStation}>
-						<header class="station-card__header">
-							<span class="station-number">{i + 1}</span>
-							<h3>{station.name}</h3>
-						</header>
-						<div class="station-card__tasks">
-							<div class="task-line">
-								<span class="task-label p1">P1</span><span class="task-text">{station.p1_task}</span
-								>
-							</div>
-							<div class="task-line">
-								<span class="task-label p2">P2</span><span class="task-text">{station.p2_task}</span
-								>
-							</div>
+	<div class="left-panel">
+		<div class="station-list">
+			{#each workout.exercises as station, i (i)}
+				{@const nextDestinationIndex = (i + 1) % totalStations}
+				<article class="station-card" class:current={i === state.currentStation}>
+					<header class="station-card__header">
+						<span class="station-number">{i + 1}</span>
+						<h3>{station.name}</h3>
+					</header>
+					<div class="station-card__tasks">
+						<div class="task-line">
+							<span class="task-label p1">P1</span><span class="task-text">{station.p1_task}</span>
 						</div>
-						<footer class="station-card__roster">
+						<div class="task-line">
+							<span class="task-label p2">P2</span><span class="task-text">{station.p2_task}</span>
+						</div>
+					</div>
+					<footer class="station-card__roster">
+						<div class="roster-line">
+							<span class="roster-title">Now Here</span>
 							<div class="roster-chips">
 								{#if stationRoster[i]?.length}
 									{#each stationRoster[i] as code, j (j)}<span>{code}</span>{/each}
-								{:else}<span class="roster-empty">OPEN</span>{/if}
+								{:else}
+									<span class="roster-empty">OPEN</span>
+								{/if}
 							</div>
-						</footer>
-					</article>
-				{/each}
-			</div>
-		</section>
+						</div>
+						<div class="roster-line destination" class:pulse={state.phaseIndex === 3}>
+							<span class="roster-title">Next Stop</span>
+							<span class="roster-destination-station">Station {nextDestinationIndex + 1}</span>
+						</div>
+					</footer>
+				</article>
+			{/each}
+		</div>
+	</div>
 
-		<section class="timer-panel">
-			<header class="timer-header">
-				<div class="header-meta">
-					<h1>{workout.title}</h1>
-					<p class="workout-meta">{workout.mode} • {workout.type}</p>
-				</div>
-				<div class="round-info">
-					<span
-						>Round {Math.min(state.currentRound, sessionConfig.rounds)}/{sessionConfig.rounds}</span
-					>
-					<span>Station {Math.min(state.currentStation + 1, totalStations)}/{totalStations}</span>
-				</div>
-			</header>
-			<main class="timer-main">
-				<div class="phase-display">{state.phase}</div>
-				{#if phaseMessage}<p class="phase-subtext">{phaseMessage}</p>{/if}
-				<div class="time-display">{formatTime(state.remaining)}</div>
-				<div class="progress-bar-container">
-					<div class="progress-bar-fill" style="width: {progress}%"></div>
-				</div>
-			</main>
-			<footer class="control-row">
-				<button on:click={resetTimer}>Reset</button>
-				<button class="primary" on:click={state.isRunning ? pauseTimer : startTimer}
-					>{state.isRunning ? 'Pause' : 'Start'}</button
+	<div class="right-panel">
+		<header class="timer-header">
+			<h1 class="workout-title">{workout.title}</h1>
+			<div class="round-info">
+				<span
+					>Round {Math.min(state.currentRound, sessionConfig.rounds)} / {sessionConfig.rounds}</span
 				>
-			</footer>
-		</section>
+				<span>Station {Math.min(state.currentStation + 1, totalStations)} / {totalStations}</span>
+			</div>
+		</header>
+		<main class="timer-main">
+			<div class="phase-display">{state.phase}</div>
+			<div class="time-display">{formatTime(state.remaining)}</div>
+			<div class="progress-bar-container">
+				<div class="progress-bar-fill" style="width: {progress}%"></div>
+			</div>
+		</main>
+		<footer class="control-row">
+			<button class="secondary" on:click={openSetup}>Setup</button>
+			<button class="secondary" on:click={resetTimer}>Reset</button>
+			<button class="primary" on:click={state.isRunning ? pauseTimer : startTimer}
+				>{state.isRunning ? 'Pause' : 'Start'}</button
+			>
+		</footer>
 	</div>
 </div>
 
 <style>
+	/* --- DESIGN SYSTEM VARIABLES --- */
 	:root {
-		--green: #065f46;
-		--yellow: #ffd60a;
+		--font-body: 'Inter', sans-serif;
+		--font-display: 'Bebas Neue', sans-serif;
+
+		--brand-yellow: #fde047; /* Brighter, more vibrant yellow */
+		--brand-green: #16a34a;
+
+		--deep-space: #0f172a;
+		--surface-1: #1e293b;
+		--surface-2: #334155;
+		--surface-3: #475569;
+
+		--text-primary: #f8fafc;
+		--text-secondary: #cbd5e1;
+		--text-muted: #94a3b8;
 	}
+
+	/* --- GLOBAL STYLES --- */
 	:global(body) {
-		background: #050505;
-		color: white;
-		font-family: 'Inter', system-ui, sans-serif;
+		background-color: var(--deep-space);
+		background-image: radial-gradient(var(--surface-1) 1px, transparent 1px);
+		background-size: 20px 20px;
+		color: var(--text-primary);
+		font-family: var(--font-body);
 	}
+
 	.blur {
-		filter: blur(10px);
+		filter: blur(8px);
 		pointer-events: none;
 	}
-	/* Modal Styles */
+
+	/* --- MODAL STYLES --- */
 	.modal-overlay {
 		position: fixed;
 		inset: 0;
-		background: rgba(0, 0, 0, 0.85);
+		background: rgba(15, 23, 42, 0.8);
 		display: flex;
 		align-items: flex-start;
 		justify-content: center;
 		z-index: 1000;
-		backdrop-filter: blur(4px);
+		backdrop-filter: blur(8px);
 		overflow-y: auto;
 		padding: 2rem 1.5rem;
 	}
 	.modal-content {
-		background: linear-gradient(145deg, #080c0a, #0d1310);
-		border: 1px solid #66ff991f;
+		background: var(--surface-1);
+		border: 1px solid var(--surface-2);
 		border-radius: 24px;
-		padding: 2.75rem;
+		padding: 2.5rem;
 		max-width: 900px;
-		width: min(96vw, 900px);
+		width: 100%;
 		text-align: left;
 		box-shadow: 0 30px 70px #00000073;
 		display: flex;
@@ -415,26 +414,27 @@
 		margin: auto 0;
 	}
 	.modal-content h2 {
-		color: var(--yellow);
+		color: var(--brand-yellow);
 		margin: 0;
-		font-size: 2rem;
+		font-family: var(--font-display);
+		font-size: 2.5rem;
+		letter-spacing: 0.08em;
 	}
 	.modal-content p {
-		color: #ffffffb8;
+		color: var(--text-secondary);
 		margin: 0;
 	}
 	.setup-form {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 		gap: 1.25rem;
-		margin-top: 1.5rem;
 	}
 	.form-group label {
 		display: block;
 		margin-bottom: 0.5rem;
-		color: #ffffffa6;
+		color: var(--text-muted);
 		font-size: 0.9rem;
-		letter-spacing: 0.05em;
+		font-weight: 600;
 		text-transform: uppercase;
 	}
 	.form-group input {
@@ -442,9 +442,9 @@
 		font-size: 1.25rem;
 		padding: 0.75rem 1rem;
 		border-radius: 12px;
-		border: 1px solid #66ff9926;
-		background: #0c120fcc;
-		color: white;
+		border: 1px solid var(--surface-2);
+		background: var(--deep-space);
+		color: var(--text-primary);
 	}
 	.assignment-setup {
 		display: flex;
@@ -453,49 +453,38 @@
 	}
 	.assignment-setup__header h3 {
 		margin: 0;
-		color: var(--yellow);
+		color: var(--brand-yellow);
 		font-size: 1.25rem;
-		text-transform: uppercase;
-	}
-	.assignment-setup__header p {
-		color: #ffffff99;
-		font-size: 0.95rem;
-		line-height: 1.5;
+		font-family: var(--font-display);
+		letter-spacing: 0.08em;
 	}
 	.assignment-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 		gap: 1.1rem;
-		padding-top: 0.5rem;
 	}
 	.assignment-card {
-		background: #0e1411cc;
-		border: 1px solid #66ff991f;
+		background: var(--surface-2);
 		border-radius: 14px;
 		padding: 1.1rem 1.25rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
 	}
 	.assignment-card label {
 		font-size: 0.85rem;
-		text-transform: uppercase;
-		color: #ffffffa6;
+		color: var(--text-secondary);
 	}
 	.assignment-card input {
 		width: 100%;
 		padding: 0.7rem 0.85rem;
+		margin-top: 0.5rem;
 		border-radius: 10px;
-		border: 1px solid #66ff992e;
-		background: #090d0bfa;
-		color: white;
-		font-size: 0.95rem;
+		border: 1px solid var(--surface-3);
+		background: var(--surface-1);
+		color: var(--text-primary);
 	}
 	.modal-actions {
 		display: flex;
 		gap: 1rem;
 		justify-content: flex-end;
-		flex-shrink: 0;
 	}
 	.modal-actions button {
 		border-radius: 999px;
@@ -506,16 +495,16 @@
 	}
 	.modal-actions button.primary {
 		border: none;
-		background: var(--green);
-		color: var(--yellow);
+		background: var(--brand-green);
+		color: var(--text-primary);
 	}
 	.modal-actions button.secondary {
-		border: 1px solid #ffffff2e;
-		background: #0f1411d9;
-		color: #ffffffd1;
+		border: 1px solid var(--surface-3);
+		background: var(--surface-2);
+		color: var(--text-secondary);
 	}
 
-	/* NEW Single-Panel Layout */
+	/* --- MAIN LAYOUT --- */
 	.timer-wrapper {
 		min-height: 100vh;
 		width: 100%;
@@ -524,63 +513,33 @@
 		align-items: stretch;
 		padding: 2rem;
 	}
-	.timer-layout {
-		width: 100%;
-		max-width: 1920px;
-		display: flex;
-		flex-direction: column;
-		gap: 2rem;
-		background: #0a0d0c;
-		border: 1px solid #66ff9914;
-		border-radius: 28px;
-		padding: 2rem;
+	.left-panel,
+	.right-panel {
+		padding: 2.5rem;
 	}
 
-	/* Top Section: Station Strip */
-	.station-overview {
-		border-bottom: 1px solid #66ff9914;
-		padding-bottom: 2rem;
-	}
-	.station-overview__header {
+	/* --- LEFT PANEL: STATION MAP --- */
+	.left-panel {
+		flex: 1 1 58%;
+		background: var(--surface-1);
+		border-radius: 28px 0 0 28px;
+		border: 1px solid var(--surface-2);
+		border-right: none;
 		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
+		flex-direction: column;
 	}
-	.station-overview__header h2 {
-		color: var(--yellow);
-		margin: 0;
-		font-size: 1.65rem;
-		text-transform: uppercase;
-	}
-	.station-overview__meta {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		font-size: 0.95rem;
-		color: #ffffff99;
-	}
-	.ghost-button {
-		border: 1px solid #ffffff33;
-		background: transparent;
-		color: #ffffffe0;
-		border-radius: 999px;
-		padding: 0.5rem 1.2rem;
-		font-size: 0.9rem;
-		font-weight: 600;
-		cursor: pointer;
-	}
-	.station-strip {
+	.station-list {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 		gap: 1rem;
+		overflow-y: auto;
+		flex-grow: 1;
+		padding: 0.2rem;
 	}
 	.station-card {
-		background: #121b16;
-		border: 1px solid #66ff9914;
-		border-radius: 18px;
+		background: var(--surface-2);
+		border: 1px solid var(--surface-3);
+		border-radius: 16px;
 		padding: 1.25rem;
 		display: flex;
 		flex-direction: column;
@@ -588,10 +547,10 @@
 		transition: all 200ms ease;
 	}
 	.station-card.current {
-		border-color: var(--yellow);
-		background: #1d2a23;
-		box-shadow: 0 10px 30px #ffd60a1a;
-		transform: translateY(-2px);
+		border-color: var(--brand-yellow);
+		background: var(--surface-3);
+		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+		transform: scale(1.03);
 	}
 	.station-card__header {
 		display: flex;
@@ -602,8 +561,8 @@
 		width: 32px;
 		height: 32px;
 		border-radius: 50%;
-		background: #ffffff1a;
-		color: #ffffffbf;
+		background: var(--surface-3);
+		color: var(--text-muted);
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -612,13 +571,14 @@
 		flex-shrink: 0;
 	}
 	.station-card.current .station-number {
-		background: var(--yellow);
-		color: #050505;
+		background: var(--brand-yellow);
+		color: var(--deep-space);
 	}
 	.station-card h3 {
 		margin: 0;
 		font-size: 1.1rem;
 		font-weight: 600;
+		color: var(--text-primary);
 	}
 	.station-card__tasks {
 		display: flex;
@@ -636,28 +596,38 @@
 		width: 24px;
 		height: 24px;
 		border-radius: 50%;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
 		font-size: 0.65rem;
 		font-weight: 700;
 		flex-shrink: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 	.task-label.p1 {
-		background: #7af5c633;
-		color: #7af5c6;
+		background: #34d39933;
+		color: #34d399;
 	}
 	.task-label.p2 {
-		background: #fbcfe833;
-		color: #fbcfe8;
+		background: #f472b633;
+		color: #f472b6;
 	}
 	.task-text {
-		color: #e6f0e8;
+		color: var(--text-secondary);
 	}
 	.station-card__roster {
-		margin-top: 0.5rem;
+		margin-top: auto;
 		padding-top: 0.75rem;
-		border-top: 1px solid #66ff9914;
+		border-top: 1px solid var(--surface-3);
+	}
+	.roster-line {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.roster-title {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		color: var(--text-muted);
 	}
 	.roster-chips {
 		display: flex;
@@ -665,123 +635,151 @@
 		gap: 0.35rem;
 	}
 	.roster-chips span {
-		display: inline-flex;
-		padding: 0.2rem 0.6rem;
-		border-radius: 8px;
-		background: rgba(255, 255, 255, 0.1);
-		color: #ffffffe0;
+		padding: 0.15rem 0.5rem;
+		border-radius: 6px;
+		background: var(--surface-3);
+		color: var(--text-secondary);
 		font-size: 0.8rem;
 		font-weight: 600;
 	}
 	.roster-empty {
-		color: #ffffff4d;
+		color: var(--surface-3);
 		font-size: 0.8rem;
 	}
+	.roster-destination-station {
+		font-size: 0.9rem;
+		font-weight: bold;
+		color: var(--text-primary);
+	}
+	.pulse .roster-destination-station {
+		animation: pulse 1.5s infinite;
+	}
+	@keyframes pulse {
+		0%,
+		100% {
+			color: var(--text-primary);
+		}
+		50% {
+			color: var(--brand-yellow);
+		}
+	}
 
-	/* Bottom Section: Timer Panel */
-	.timer-panel {
+	/* --- RIGHT PANEL: LIVE TIMER --- */
+	.right-panel {
+		flex: 1 1 42%;
+		background: linear-gradient(160deg, var(--deep-space), #000000);
+		border-radius: 0 28px 28px 0;
+		border: 1px solid var(--surface-2);
+		border-left: none;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		text-align: center;
-		width: 100%;
-		flex-grow: 1;
-		justify-content: center;
 	}
 	.timer-header {
 		width: 100%;
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
-		gap: 2rem;
-	}
-	.header-meta {
 		text-align: left;
 	}
-	.header-meta h1 {
-		margin: 0;
-		color: var(--yellow);
-		font-size: clamp(2rem, 4vw, 3rem);
-		text-transform: uppercase;
-	}
-	.workout-meta {
-		margin-top: 0.5rem;
-		color: #ffffffa6;
-		letter-spacing: 0.1em;
-		text-transform: uppercase;
-		font-size: 0.95rem;
+	.workout-title {
+		font-family: var(--font-display);
+		font-size: clamp(3rem, 6vw, 4.5rem);
+		color: var(--brand-yellow);
+		line-height: 1;
+		letter-spacing: 2px;
 	}
 	.round-info {
 		display: flex;
 		gap: 1rem;
-		color: #ffffffc9;
-		font-size: 1.1rem;
+		color: var(--text-muted);
 		text-transform: uppercase;
-	}
-	.round-info span {
-		display: inline-flex;
-		padding: 0.55rem 1.2rem;
-		border-radius: 999px;
-		background: #ffffff0f;
+		font-size: 1.1rem;
+		margin-top: 0.5rem;
 	}
 	.timer-main {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		width: 100%;
+		flex-grow: 1;
+		justify-content: center;
 	}
 	.phase-display {
-		font-size: clamp(2rem, 5vw, 3.5rem);
-		font-weight: 300;
-		text-transform: uppercase;
-		color: #dddddd;
-	}
-	.phase-subtext {
-		margin-top: -0.5rem;
-		font-size: 1.1rem;
-		color: #ffffffb8;
-		font-style: italic;
+		font-family: var(--font-display);
+		font-size: clamp(3rem, 8vw, 5rem);
+		color: var(--text-primary);
+		letter-spacing: 4px;
 	}
 	.time-display {
-		font-size: clamp(8rem, 20vw, 16rem);
-		font-weight: 800;
+		font-family: var(--font-display);
+		font-size: clamp(10rem, 28vw, 20rem);
+		font-weight: 400;
 		line-height: 1;
-		font-family: monospace;
-		margin: 1.5rem 0;
+		margin: 1rem 0;
+		color: var(--text-primary);
 	}
 	.progress-bar-container {
-		width: min(860px, 100%);
-		height: 10px;
-		background: #1a1f1d;
+		width: 100%;
+		max-width: 600px;
+		height: 8px;
+		background: var(--surface-2);
 		border-radius: 999px;
 		overflow: hidden;
 	}
 	.progress-bar-fill {
 		height: 100%;
-		background: var(--yellow);
+		background: var(--brand-yellow);
 	}
 	.control-row {
 		display: flex;
 		justify-content: center;
 		gap: 1rem;
-		flex-wrap: wrap;
 		width: 100%;
-		margin-top: 2rem;
+		margin-top: auto;
+		padding-top: 1.5rem;
 	}
 	.control-row button {
-		border: 1px solid #66ff9938;
-		background: #131a17;
-		color: #ffffffe0;
+		border: 1px solid var(--surface-3);
+		background: var(--surface-2);
+		color: var(--text-secondary);
 		border-radius: 999px;
 		font-size: 1.1rem;
 		padding: 0.9rem 2.5rem;
 		cursor: pointer;
-		min-width: 160px;
 		font-weight: 600;
 	}
 	.control-row button.primary {
-		background: var(--green);
+		background: var(--brand-green);
 		border-color: transparent;
-		color: var(--yellow);
+		color: var(--text-primary);
+	}
+
+	/* --- RESPONSIVE ADJUSTMENTS --- */
+	@media (max-width: 1200px) {
+		.timer-wrapper {
+			flex-direction: column;
+			padding: 1rem;
+		}
+		.left-panel {
+			border-radius: 28px 28px 0 0;
+			border-right: 1px solid var(--surface-2);
+			border-bottom: none;
+			max-height: 50vh;
+		}
+		.right-panel {
+			border-radius: 0 0 28px 28px;
+			border-left: 1px solid var(--surface-2);
+		}
+	}
+	@media (max-width: 768px) {
+		.station-list {
+			grid-template-columns: 1fr;
+		}
+		.left-panel,
+		.right-panel {
+			padding: 1.5rem;
+		}
+		.time-display {
+			font-size: clamp(6rem, 25vw, 10rem);
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- add Google Fonts preconnect and stylesheet links to the root layout
- replace the timer page with the redesigned UI, maintaining timer logic and roster assignments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4645594a0832fac255e30040898b9