### PR TITLE
Fix admin burger menu visibility for admin users

### DIFF
--- a/workout-app/src/routes/+layout.svelte
+++ b/workout-app/src/routes/+layout.svelte
@@ -23,8 +23,9 @@
 				const profileRef = doc(db, 'profiles', firebaseUser.uid);
 				const profileSnap = await getDoc(profileRef);
 
-				if (profileSnap.exists()) {
-					$isAdmin = profileSnap.data().isAdmin === true;
+                                if (profileSnap.exists()) {
+                                        const profileData = profileSnap.data();
+                                        $isAdmin = Boolean(profileData?.isAdmin);
 				} else {
 					$isAdmin = false;
 					if (window.location.pathname !== '/account/setup') {


### PR DESCRIPTION
## Summary
- treat stored profile admin flags as truthy values so admin users keep their menu access

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e61b6c5488832f9d4416278317253d