### PR TITLE
Handle missing workout linkage in live session loader

### DIFF
--- a/workout-app/src/routes/live/[sessionId]/+page.js
+++ b/workout-app/src/routes/live/[sessionId]/+page.js
@@ -5,27 +5,33 @@ import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ params }) {
-	// First, get the session data
-	const sessionRef = doc(db, 'sessions', params.sessionId);
-	const sessionSnap = await getDoc(sessionRef);
+    // Get the session data
+    const sessionRef = doc(db, 'sessions', params.sessionId);
+    const sessionSnap = await getDoc(sessionRef);
 
-	if (!sessionSnap.exists()) {
-		throw error(404, 'Session not found');
-	}
-	const session = { id: sessionSnap.id, ...sessionSnap.data() };
+    if (!sessionSnap.exists()) {
+        throw error(404, 'Session not found');
+    }
+    const session = { id: sessionSnap.id, ...sessionSnap.data() };
 
-	// Now, use the workoutId from the session to get the workout details
-	const workoutRef = doc(db, 'workouts', session.workoutId);
-	const workoutSnap = await getDoc(workoutRef);
+    // --- THIS IS THE FIX ---
+    // Check if the workoutId exists on the session before trying to fetch it
+    if (!session.workoutId) {
+        throw error(500, 'This session does not have a workout linked to it. Please create a new session and assign a workout.');
+    }
+    // --- END OF FIX ---
 
-	if (!workoutSnap.exists()) {
-		throw error(404, 'Workout for this session not found');
-	}
-	const workout = { id: workoutSnap.id, ...workoutSnap.data() };
+    // Now, use the workoutId from the session to get the workout details
+    const workoutRef = doc(db, 'workouts', session.workoutId);
+    const workoutSnap = await getDoc(workoutRef);
 
-	// Return both so the page has all the info it needs
-	return {
-		session,
-		workout
-	};
+    if (!workoutSnap.exists()) {
+        throw error(404, `The assigned workout (ID: ${session.workoutId}) could not be found.`);
+    }
+    const workout = { id: workoutSnap.id, ...workoutSnap.data() };
+
+    return {
+        session,
+        workout
+    };
 }


### PR DESCRIPTION
## Summary
- add a guard that throws an informative error when a live session lacks a linked workout
- surface a descriptive 404 if the linked workout document cannot be retrieved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e649e29ba4832f9cf34ab1f11c7f5b