### PR TITLE
Revamp live timer page layout and controls

### DIFF
--- a/workout-app/src/routes/timer/[id]/+page.svelte
+++ b/workout-app/src/routes/timer/[id]/+page.svelte
@@ -1,192 +1,921 @@
 <script>
-// @ts-nocheck
-import { onDestroy } from 'svelte';
-import { db } from '$lib/firebase';
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+	// @ts-nocheck
+	import { onDestroy, onMount } from 'svelte';
+	import { db } from '$lib/firebase';
+	import { collection, query, where, getDocs, orderBy, limit } from 'firebase/firestore';
 
-export let data;
-const { workout, sessionId, url } = data;
+	export let data;
+	const { workout, url } = data;
 
-// --- Sound Functions ---
-let audioCtx = null;
-function getCtx() { return audioCtx || (audioCtx = new (window.AudioContext || window.webkitAudioContext)()); }
-function tone(freq = 800, dur = 200, type = 'sine', gain = 0.25) { try { const ctx = getCtx(); const o = ctx.createOscillator(); const g = ctx.createGain(); o.type = type; o.frequency.setValueAtTime(freq, ctx.currentTime); o.connect(g); g.connect(ctx.destination); g.gain.setValueAtTime(gain, ctx.currentTime); g.gain.exponentialRampToValueAtTime(1e-4, ctx.currentTime + dur / 1000); o.start(); o.stop(ctx.currentTime + dur / 1000); } catch (e) {} }
-function whistleBell() { try { const ctx = getCtx(); for (let i = 0; i < 2; i += 1) { const g = ctx.createGain(); const t0 = ctx.currentTime + i * 0.15; g.connect(ctx.destination); g.gain.setValueAtTime(1e-4, t0); g.gain.linearRampToValueAtTime(i === 0 ? 0.85 : 0.7, t0 + 0.02); g.gain.exponentialRampToValueAtTime(1e-4, t0 + 1.2); const o1 = ctx.createOscillator(); const o2 = ctx.createOscillator(); o1.type = 'triangle'; o2.type = 'triangle'; o1.frequency.setValueAtTime(620, t0); o2.frequency.setValueAtTime(930, t0); o1.connect(g); o2.connect(g); o1.start(t0); o2.start(t0); o1.stop(t0 + 1.25); o2.stop(t0 + 1.25); } } catch (e) {} }
-function countBeep(n) { const f = { 3: 520, 2: 680, 1: 940 }; tone(f[n] || 720, 180, 'sine', 0.35); }
+	// --- Sound Functions ---
+	let audioCtx = null;
+	function getCtx() {
+		return audioCtx || (audioCtx = new (window.AudioContext || window.webkitAudioContext)());
+	}
+	function tone(freq = 800, dur = 200, type = 'sine', gain = 0.25) {
+		try {
+			const ctx = getCtx();
+			const o = ctx.createOscillator();
+			const g = ctx.createGain();
+			o.type = type;
+			o.frequency.setValueAtTime(freq, ctx.currentTime);
+			o.connect(g);
+			g.connect(ctx.destination);
+			g.gain.setValueAtTime(gain, ctx.currentTime);
+			g.gain.exponentialRampToValueAtTime(1e-4, ctx.currentTime + dur / 1000);
+			o.start();
+			o.stop(ctx.currentTime + dur / 1000);
+		} catch (error) {
+			console.error('Failed to play tone', error);
+		}
+	}
+	function whistleBell() {
+		try {
+			const ctx = getCtx();
+			for (let i = 0; i < 2; i += 1) {
+				const g = ctx.createGain();
+				const t0 = ctx.currentTime + i * 0.15;
+				g.connect(ctx.destination);
+				g.gain.setValueAtTime(1e-4, t0);
+				g.gain.linearRampToValueAtTime(i === 0 ? 0.85 : 0.7, t0 + 0.02);
+				g.gain.exponentialRampToValueAtTime(1e-4, t0 + 1.2);
+				const o1 = ctx.createOscillator();
+				const o2 = ctx.createOscillator();
+				o1.type = 'triangle';
+				o2.type = 'triangle';
+				o1.frequency.setValueAtTime(620, t0);
+				o2.frequency.setValueAtTime(930, t0);
+				o1.connect(g);
+				o2.connect(g);
+				o1.start(t0);
+				o2.start(t0);
+				o1.stop(t0 + 1.25);
+				o2.stop(t0 + 1.25);
+			}
+		} catch (error) {
+			console.error('Failed to play bell', error);
+		}
+	}
+	function countBeep(n) {
+		const f = { 3: 520, 2: 680, 1: 940 };
+		tone(f[n] || 720, 180, 'sine', 0.35);
+	}
 
-// --- Session State ---
-let sessionConfig = { work: 60, swap: 15, move: 15, rounds: 1, totalTime: 600, showStationCallout: false, amrapTagline: '' };
-let state = { phase: 'Ready', phaseIndex: -1, remaining: 60, duration: 60, currentStation: 0, currentRound: 1, isRunning: false, isComplete: false, lastCue: 0 };
-let timerId = null;
-let isSetupVisible = false;
-let showQr = false;
+	// --- Session State ---
+	let sessionConfig = {
+		work: workout?.timer?.work ?? 60,
+		swap: workout?.timer?.swap ?? 15,
+		move: workout?.timer?.move ?? 15,
+		rounds: workout?.timer?.rounds ?? 1,
+		totalTime: workout?.timer?.totalTime ?? 600
+	};
+	const getNumber = (value, fallback = 0) => {
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : fallback;
+	};
+	let state = {
+		phase: 'Ready',
+		phaseIndex: -1,
+		remaining: sessionConfig.work,
+		duration: sessionConfig.work,
+		currentStation: 0,
+		currentRound: 1,
+		isRunning: false,
+		isComplete: false,
+		lastCue: 0
+	};
+	let timerId = null;
+	let isSetupVisible = false;
+	let showQr = false;
+	let sessionId = data.sessionId ?? null;
 
-// --- AMRAP / Benchmark State ---
-let amrapMinutes = sessionConfig.totalTime / 60;
-const defaultAmrapTagline = (minutes) => `As Many Rounds As Possible in ${Math.max(1, Math.round(minutes || 0))} minutes`;
-sessionConfig.amrapTagline = workout.amrapTagline || defaultAmrapTagline(amrapMinutes);
-let amrapTaglineDirty = Boolean(workout.amrapTagline);
-function makeId() { return Math.random().toString(36).slice(2, 8); }
-let attendeeRecords = Array.isArray(workout.attendees) ? workout.attendees.map(name => ({ id: makeId(), name, rounds: '' })) : [];
-let attendeeInput = attendeeRecords.map(record => record.name).join('\n');
-let isSavingResults = false;
-let hasSavedResults = false;
-let resultsStatus = { type: 'idle', message: '' };
+	// --- Roster Logic ---
+	let totalStations = workout.exercises?.length ?? 0;
+	let stationAssignments = (workout.exercises ?? []).map((station) => station?.assignments ?? []);
+	let assignmentInputs = stationAssignments.map((codes) => codes.join(', '));
 
-// --- Roster Logic ---
-let totalStations = workout.exercises?.length ?? 0;
-let stationAssignments = (workout.exercises ?? []).map(() => []);
-let assignmentInputs = (workout.exercises ?? []).map(() => '');
+	function parseAssignments(value = '') {
+		return value
+			.split(/[\n,]/)
+			.map((c) => c.trim())
+			.filter(Boolean)
+			.map((c) => c.toUpperCase());
+	}
+	function commitAllAssignments() {
+		stationAssignments = stationAssignments.map((codes, i) =>
+			parseAssignments(assignmentInputs[i] ?? codes.join(', '))
+		);
+		assignmentInputs = stationAssignments.map((codes) => codes.join(', '));
+	}
 
-function parseAssignments(value = '') { return value.split(/[\n,]/).map(c => c.trim()).filter(Boolean).map(c => c.toUpperCase()); }
-function commitAllAssignments() {
-stationAssignments = stationAssignments.map((codes, i) => parseAssignments(assignmentInputs[i] ?? codes.join(', ')));
-assignmentInputs = stationAssignments.map(codes => codes.join(', '));
-}
+	// --- AMRAP Attendees ---
+	let attendeeInput = Array.isArray(workout.attendees) ? workout.attendees.join('\n') : '';
+	$: attendees = attendeeInput
+		.split(/\n+/)
+		.map((name) => name.trim())
+		.filter(Boolean);
 
-$: progress = state.duration > 0 ? Math.min(100, Math.max(0, ((state.duration - state.remaining) / state.duration) * 100)) : 0;
+	// --- Derived State ---
+	$: movesCompleted =
+		totalStations > 0 ? (state.currentRound - 1) * totalStations + state.currentStation : 0;
+	$: stationRoster = (workout.exercises ?? []).map((_, targetIndex) => {
+		if (!totalStations) return [];
+		const roster = [];
+		stationAssignments.forEach((codes, startIndex) => {
+			if (codes?.length) {
+				const dest = (startIndex + movesCompleted) % totalStations;
+				if (dest === targetIndex) {
+					roster.push(...codes);
+				}
+			}
+		});
+		return roster;
+	});
+	$: progress =
+		state.duration > 0
+			? Math.min(100, Math.max(0, ((state.duration - state.remaining) / state.duration) * 100))
+			: 0;
+	$: totalRounds = Math.max(getNumber(sessionConfig.rounds, 1), 1);
+	$: workSeconds = getNumber(sessionConfig.work, 0);
+	$: swapSeconds = getNumber(sessionConfig.swap, 0);
+	$: moveSeconds = getNumber(sessionConfig.move, 0);
+	$: amrapSeconds = getNumber(sessionConfig.totalTime, 0);
+	$: totalTime =
+		workout.type === 'AMRAP'
+			? Math.round(amrapSeconds / 60)
+			: totalStations > 0
+				? Math.round(
+						((workout.mode === 'Partner'
+							? workSeconds * 2 + swapSeconds + moveSeconds
+							: workSeconds + moveSeconds) *
+							totalStations *
+							totalRounds) /
+							60
+					)
+				: 0;
 
-// --- Timer Logic ---
-function advancePhase() {
-if (state.isComplete || !totalStations) return;
-state.lastCue = 0;
-const nextPhaseIndex = state.phaseIndex + 1;
+	onMount(async () => {
+		if (sessionId) return;
+		try {
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity
+			const startOfToday = new Date();
+			startOfToday.setHours(0, 0, 0, 0);
+			const sessionsQuery = query(
+				collection(db, 'sessions'),
+				where('workoutId', '==', workout.id),
+				where('sessionDate', '>=', startOfToday),
+				orderBy('sessionDate', 'asc'),
+				limit(1)
+			);
+			const sessionsSnapshot = await getDocs(sessionsQuery);
+			if (!sessionsSnapshot.empty) {
+				sessionId = sessionsSnapshot.docs[0].id;
+			}
+		} catch (err) {
+			console.error('Failed to load session QR code', err);
+		}
+	});
 
-if (workout.type === 'Circuit' || workout.type === 'Timed Rounds') {
-if (workout.mode === 'Partner') {
-if (nextPhaseIndex === 0) { state.phaseIndex = 0; state.phase = 'WORK 1'; state.remaining = state.duration = sessionConfig.work; whistleBell(); } 
-else if (nextPhaseIndex === 1) { state.phaseIndex = 1; state.phase = 'SWAP'; state.remaining = state.duration = sessionConfig.swap; tone(420, 160); } 
-else if (nextPhaseIndex === 2) { state.phaseIndex = 2; state.phase = 'WORK 2'; state.remaining = state.duration = sessionConfig.work; whistleBell(); } 
-else if (nextPhaseIndex === 3) { state.phaseIndex = 3; state.phase = 'MOVE'; state.remaining = state.duration = sessionConfig.move; tone(420, 160); } 
-else {
-state.currentStation++;
-if (state.currentStation >= totalStations) {
-state.currentStation = 0; state.currentRound++;
-if (state.currentRound > sessionConfig.rounds) { workoutComplete(); return; }
-}
-state.phaseIndex = 0; state.phase = 'WORK 1'; state.remaining = state.duration = sessionConfig.work; whistleBell();
-}
-} else { // Individual Circuit
-if (nextPhaseIndex % 2 === 0) { state.phase = 'WORK'; state.remaining = state.duration = sessionConfig.work; whistleBell(); } 
-else {
-state.currentStation++;
-if (state.currentStation >= totalStations) {
-state.currentStation = 0; state.currentRound++;
-if (state.currentRound > sessionConfig.rounds) { workoutComplete(); return; }
-}
-state.phase = 'MOVE'; state.remaining = state.duration = sessionConfig.move; tone(420, 160);
-}
-state.phaseIndex = nextPhaseIndex;
-}
-} else if (workout.type === 'EMOM') {
-state.currentRound++;
-if (state.currentRound > sessionConfig.rounds) { workoutComplete(); return; }
-state.phase = `Minute ${state.currentRound}`;
-state.remaining = state.duration = 60;
-state.currentStation = (state.currentRound - 1) % totalStations;
-whistleBell();
-}
-}
+	// --- Timer Logic ---
+	function advancePhase() {
+		if (state.isComplete || (!totalStations && workout.type !== 'AMRAP')) return;
+		state.lastCue = 0;
+		const nextPhaseIndex = state.phaseIndex + 1;
 
-function tick() {
-state.remaining = Math.max(0, state.remaining - 0.1);
-const secs = Math.ceil(state.remaining);
-if (secs <= 3 && secs >= 1 && secs !== state.lastCue) { state.lastCue = secs; countBeep(secs); }
-if (state.remaining <= 0) {
-if (workout.type === 'AMRAP') { workoutComplete(); } else { advancePhase(); }
-}
-state = state;
-}
+		if (workout.type === 'Circuit' || workout.type === 'Timed Rounds') {
+			if (workout.mode === 'Partner') {
+				if (nextPhaseIndex === 0) {
+					state.phaseIndex = 0;
+					state.phase = 'WORK 1';
+					state.remaining = state.duration = workSeconds;
+					whistleBell();
+				} else if (nextPhaseIndex === 1) {
+					state.phaseIndex = 1;
+					state.phase = 'SWAP';
+					state.remaining = state.duration = swapSeconds;
+					tone(420, 160);
+				} else if (nextPhaseIndex === 2) {
+					state.phaseIndex = 2;
+					state.phase = 'WORK 2';
+					state.remaining = state.duration = workSeconds;
+					whistleBell();
+				} else if (nextPhaseIndex === 3) {
+					state.phaseIndex = 3;
+					state.phase = 'MOVE';
+					state.remaining = state.duration = moveSeconds;
+					tone(420, 160);
+				} else {
+					state.currentStation++;
+					if (state.currentStation >= totalStations) {
+						state.currentStation = 0;
+						state.currentRound++;
+						if (state.currentRound > totalRounds) {
+							workoutComplete();
+							return;
+						}
+					}
+					state.phaseIndex = 0;
+					state.phase = 'WORK 1';
+					state.remaining = state.duration = workSeconds;
+					whistleBell();
+				}
+			} else {
+				if (nextPhaseIndex % 2 === 0) {
+					state.phase = 'WORK';
+					state.remaining = state.duration = workSeconds;
+					whistleBell();
+				} else {
+					state.currentStation++;
+					if (state.currentStation >= totalStations) {
+						state.currentStation = 0;
+						state.currentRound++;
+						if (state.currentRound > totalRounds) {
+							workoutComplete();
+							return;
+						}
+					}
+					state.phase = 'MOVE';
+					state.remaining = state.duration = moveSeconds;
+					tone(420, 160);
+				}
+				state.phaseIndex = nextPhaseIndex;
+			}
+		} else if (workout.type === 'EMOM') {
+			state.currentRound++;
+			if (state.currentRound > totalRounds) {
+				workoutComplete();
+				return;
+			}
+			state.phase = `Minute ${state.currentRound}`;
+			state.remaining = state.duration = 60;
+			state.currentStation = (state.currentRound - 1) % Math.max(totalStations, 1);
+			whistleBell();
+		}
+	}
 
-function startTimer() {
-if (state.isComplete || state.isRunning) return;
-if (workout.type !== 'AMRAP' && totalStations === 0) return;
-if (state.phaseIndex === -1) {
-if (workout.type === 'AMRAP') {
-state.phase = 'WORK'; state.remaining = state.duration = sessionConfig.totalTime;
-state.phaseIndex = 0; whistleBell();
-} else {
-advancePhase();
-}
-}
-state.isRunning = true;
-timerId = setInterval(tick, 100);
-}
+	function tick() {
+		state.remaining = Math.max(0, state.remaining - 0.1);
+		const secs = Math.ceil(state.remaining);
+		if (secs <= 3 && secs >= 1 && secs !== state.lastCue) {
+			state.lastCue = secs;
+			countBeep(secs);
+		}
+		if (state.remaining <= 0) {
+			if (workout.type === 'AMRAP') {
+				workoutComplete();
+			} else {
+				advancePhase();
+			}
+		}
+		state = state;
+	}
 
-function pauseTimer() { if (!state.isRunning) return; state.isRunning = false; clearInterval(timerId); timerId = null; }
+	function startTimer() {
+		if (state.isComplete || state.isRunning) return;
+		if (workout.type !== 'AMRAP' && totalStations === 0) return;
+		if (state.phaseIndex === -1) {
+			if (workout.type === 'AMRAP') {
+				state.phase = 'WORK';
+				state.remaining = state.duration = amrapSeconds;
+				state.phaseIndex = 0;
+				whistleBell();
+			} else {
+				advancePhase();
+			}
+		}
+		state.isRunning = true;
+		timerId = setInterval(tick, 100);
+	}
 
-function resetTimer() {
-pauseTimer();
-state.phase = 'Ready'; state.phaseIndex = -1; state.currentStation = 0;
-state.currentRound = 1; state.isComplete = false; hasSavedResults = false;
-resultsStatus = { type: 'idle', message: '' };
-attendeeRecords = attendeeRecords.map(record => ({ ...record, rounds: '' }));
-if (workout.type === 'AMRAP') { state.remaining = state.duration = sessionConfig.totalTime; } 
-else if (workout.type === 'EMOM') { state.remaining = state.duration = 60; } 
-else { state.remaining = state.duration = sessionConfig.work; }
-state = state;
-}
+	function pauseTimer() {
+		if (!state.isRunning) return;
+		state.isRunning = false;
+		clearInterval(timerId);
+		timerId = null;
+	}
 
-function skipPhase() { if (state.isComplete || state.phaseIndex === -1 || totalStations === 0) return; const wasRunning = state.isRunning; pauseTimer(); advancePhase(); if (wasRunning && !state.isComplete) { startTimer(); } }
+	function resetTimer() {
+		pauseTimer();
+		state.phase = 'Ready';
+		state.phaseIndex = -1;
+		state.currentStation = 0;
+		state.currentRound = 1;
+		state.isComplete = false;
+		state.lastCue = 0;
+		if (workout.type === 'AMRAP') {
+			state.remaining = state.duration = amrapSeconds;
+		} else if (workout.type === 'EMOM') {
+			state.remaining = state.duration = 60;
+		} else {
+			state.remaining = state.duration = workSeconds;
+		}
+		state = state;
+	}
 
-function workoutComplete() { pauseTimer(); state.phase = 'SESSION COMPLETE!'; state.isComplete = true; state.remaining = 0; state = state; whistleBell(); }
+	function workoutComplete() {
+		pauseTimer();
+		state.phase = 'SESSION COMPLETE!';
+		state.isComplete = true;
+		state.remaining = 0;
+		state = state;
+		whistleBell();
+	}
 
-function applySetup() { commitAllAssignments(); applyAttendeeInput(); isSetupVisible = false; resetTimer(); }
-function openSetup() { pauseTimer(); attendeeInput = attendeeRecords.map(r => r.name).join('\n'); isSetupVisible = true; }
-function closeSetup() { isSetupVisible = false; }
+	function openSetup() {
+		pauseTimer();
+		isSetupVisible = true;
+	}
+	function closeSetup() {
+		commitAllAssignments();
+		isSetupVisible = false;
+	}
 
-function formatTime(s) { const secs = Math.max(0, Math.ceil(s)); return (String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0')); }
+	function formatTime(s) {
+		const secs = Math.max(0, Math.ceil(s));
+		return (
+			String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0')
+		);
+	}
 
-function getExerciseDetail(exercise) { return (exercise?.description || exercise?.target || exercise?.reps || exercise?.details || ''); }
-
-async function saveAmrapResults() { /* ... function from previous turn ... */ }
-
-$: startButtonLabel = state.isRunning ? 'Pause' : (state.phaseIndex >= 0 && !state.isComplete ? 'Resume' : 'Start');
-
-onDestroy(() => clearInterval(timerId));
+	onDestroy(() => clearInterval(timerId));
 </script>
 
-{#if showQr}
-  <div class="modal-overlay" on:click={() => (showQr = false)}>
-    <div class="modal-content qr-modal">
-      <h2>Scan to Join Session</h2>
-      <p>Members can scan this code with their phone's camera to join the live session.</p>
-      <img
-        src={`https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(
-          `https://${url.host}/live/${sessionId}`
-        )}`}
-        alt="QR Code to join session"
-      />
-    </div>
-  </div>
+{#if isSetupVisible}
+	<div class="modal-overlay" on:click|self={closeSetup}>
+		<div class="modal-content">
+			<h2>{workout.type === 'AMRAP' ? 'Attendee List' : 'Session Roster Setup'}</h2>
+			{#if workout.type === 'AMRAP'}
+				<div class="attendee-setup">
+					<p>
+						Enter attendee names on separate lines. This list will sync with the live leaderboard.
+					</p>
+					<textarea bind:value={attendeeInput} placeholder="Add each attendee on a new line"
+					></textarea>
+					<p class="attendee-count">
+						{attendees.length} attendee{attendees.length === 1 ? '' : 's'} listed
+					</p>
+				</div>
+			{:else if workout.mode === 'Partner'}
+				<div class="assignment-setup">
+					<p>Enter staff initials for each starting station. They will rotate automatically.</p>
+					<div class="assignment-grid">
+						{#each workout.exercises as station, i (station.id ?? i)}
+							<div class="assignment-card">
+								<label for={`assignment-${i}`}>Station {i + 1}: {station.name}</label>
+								<input
+									id={`assignment-${i}`}
+									placeholder="e.g. LMN, DVE"
+									bind:value={assignmentInputs[i]}
+									on:blur={commitAllAssignments}
+								/>
+							</div>
+						{/each}
+					</div>
+				</div>
+			{:else}
+				<p>Roster setup is only available for Partner workouts.</p>
+			{/if}
+			<div class="modal-actions"><button class="primary" on:click={closeSetup}>Done</button></div>
+		</div>
+	</div>
 {/if}
 
-<header class="setup-panel">
-  <div class="logo"><span>{workout.title}</span></div>
-  <div class="setup-controls">
-    <div class="form-group">
-      <label>&nbsp;</label>
-      <button class="roster-btn" on:click={openSetup}>Setup Roster</button>
-    </div>
-    <div class="form-group">
-      <label>&nbsp;</label>
-      <button class="roster-btn" on:click={() => (showQr = true)}>Show QR Code</button>
-    </div>
-  </div>
-</header>
+{#if showQr && sessionId}
+	<div class="modal-overlay" on:click|self={() => (showQr = false)}>
+		<div class="modal-content qr-modal">
+			<h2>Scan to Join Live Session</h2>
+			<p>Members can scan this with their phone to open the personal score tracker.</p>
+			<img
+				src={`https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(`${url.origin}/live/${sessionId}`)}`}
+				alt="QR Code to join session"
+			/>
+		</div>
+	</div>
+{/if}
+
+<div class="mission-control" class:blur={isSetupVisible || showQr}>
+	<header class="setup-panel">
+		<div class="logo"><span>{workout.title}</span></div>
+		<div class="setup-controls">
+			<div class="form-group">
+				<label for="work">Work (s)</label>
+				<input
+					id="work"
+					type="number"
+					min="0"
+					bind:value={sessionConfig.work}
+					disabled={state.isRunning}
+				/>
+			</div>
+			<div class="form-group">
+				<label for="swap">Swap (s)</label>
+				<input
+					id="swap"
+					type="number"
+					min="0"
+					bind:value={sessionConfig.swap}
+					disabled={state.isRunning || workout.mode !== 'Partner'}
+				/>
+			</div>
+			<div class="form-group">
+				<label for="move">Move (s)</label>
+				<input
+					id="move"
+					type="number"
+					min="0"
+					bind:value={sessionConfig.move}
+					disabled={state.isRunning}
+				/>
+			</div>
+			<div class="form-group">
+				<label for="rounds">Rounds</label>
+				<input
+					id="rounds"
+					type="number"
+					min="1"
+					bind:value={sessionConfig.rounds}
+					disabled={state.isRunning}
+				/>
+			</div>
+			<div class="form-group">
+				<label>&nbsp;</label>
+				<button class="roster-btn" on:click={openSetup}>Roster</button>
+			</div>
+			<div class="form-group">
+				<label>&nbsp;</label>
+				<button class="roster-btn" on:click={() => (showQr = true)} disabled={!sessionId}
+					>QR Code</button
+				>
+			</div>
+		</div>
+	</header>
+
+	<main class="main-content">
+		<div class="left-panel">
+			<div class="station-grid">
+				{#each workout.exercises as station, i (station.id ?? i)}
+					<article class="station-card" class:current={i === state.currentStation}>
+						<header class="station-card__header">
+							<span class="station-number">{i + 1}</span>
+							<h3>{station.name}</h3>
+							{#if station.shared}
+								<span class="shared-badge">Shared</span>
+							{/if}
+						</header>
+						<div class="station-card__tasks">
+							<div class="task-line">
+								<span class="task-label p1">P1</span><span class="task-text">{station.p1_task}</span
+								>
+							</div>
+							{#if station.p2_task}
+								<div class="task-line">
+									<span class="task-label p2">P2</span><span class="task-text"
+										>{station.p2_task}</span
+									>
+								</div>
+							{/if}
+						</div>
+						<footer class="station-card__roster">
+							<div class="roster-chips">
+								{#if stationRoster[i]?.length}
+									{#each stationRoster[i] as code, codeIndex (code + codeIndex)}<span>{code}</span
+										>{/each}
+								{:else}
+									<span class="roster-empty">OPEN</span>
+								{/if}
+							</div>
+						</footer>
+					</article>
+				{/each}
+			</div>
+		</div>
+		<div class="right-panel">
+			<main class="timer-main">
+				<div class="phase-display">{state.phase}</div>
+				<div class="time-display">{formatTime(state.remaining)}</div>
+				<div class="progress-bar-container">
+					<div class="progress-bar-fill" style={`width: ${progress}%`}></div>
+				</div>
+			</main>
+			<footer class="timer-footer">
+				<div class="meta-info">
+					<span
+						>Station {Math.min(state.currentStation + 1, Math.max(totalStations, 1))}/{Math.max(
+							totalStations,
+							1
+						)}</span
+					>
+					<span
+						>Round {Math.min(state.currentRound, Number(sessionConfig.rounds) || 1)}/{Number(
+							sessionConfig.rounds
+						) || 1}</span
+					>
+					<span>Total: ~{totalTime} min</span>
+				</div>
+				<div class="control-row">
+					<button class="primary" on:click={state.isRunning ? pauseTimer : startTimer}
+						>{state.isRunning ? 'Pause' : 'Start'}</button
+					>
+					<button class="secondary" on:click={resetTimer}>Reset</button>
+				</div>
+			</footer>
+		</div>
+	</main>
+</div>
 
 <style>
-/* Final, clean CSS */
+	:root {
+		--font-body: 'Inter', sans-serif;
+		--font-display: 'Bebas Neue', sans-serif;
+		--brand-yellow: #fde047;
+		--brand-green: #16a34a;
+		--bg-main: #111827;
+		--bg-panel: #1f2937;
+		--border-color: #374151;
+		--text-primary: #f9fafb;
+		--text-secondary: #9ca3af;
+		--text-muted: #6b7280;
+	}
+	:global(body) {
+		background-color: var(--bg-main);
+		color: var(--text-primary);
+		font-family: var(--font-body);
+	}
+	.blur {
+		filter: blur(8px);
+	}
 
-/* ADD THESE STYLES for the QR Modal */
-.qr-modal {
-  text-align: center;
-}
+	/* Modals */
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(17, 24, 39, 0.8);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		backdrop-filter: blur(8px);
+		padding: 1.5rem;
+	}
+	.modal-content {
+		background: var(--bg-panel);
+		border: 1px solid var(--border-color);
+		border-radius: 24px;
+		padding: 2.5rem;
+		max-width: 900px;
+		width: 100%;
+		box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		max-height: 90vh;
+	}
+	.modal-content h2 {
+		font-family: var(--font-display);
+		color: var(--brand-yellow);
+		font-size: 2.5rem;
+		letter-spacing: 1px;
+		margin: 0;
+	}
+	.assignment-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+		gap: 1rem;
+		overflow-y: auto;
+		padding: 0.5rem;
+		max-height: 50vh;
+	}
+	.assignment-card {
+		background: var(--bg-main);
+		border-radius: 14px;
+		padding: 1rem;
+	}
+	.assignment-card label {
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+	}
+	.assignment-card input {
+		width: 100%;
+		padding: 0.5rem;
+		margin-top: 0.5rem;
+		border-radius: 8px;
+		border: 1px solid var(--border-color);
+		background: var(--bg-panel);
+		color: var(--text-primary);
+	}
+	.attendee-setup textarea {
+		width: 100%;
+		min-height: 200px;
+		border-radius: 12px;
+		padding: 1rem;
+		border: 1px solid var(--border-color);
+		background: var(--bg-main);
+		color: var(--text-primary);
+		font-size: 1rem;
+	}
+	.attendee-count {
+		margin-top: 0.75rem;
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+	}
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+	}
+	.modal-actions button {
+		border-radius: 999px;
+		font-size: 1rem;
+		padding: 0.75rem 2rem;
+		cursor: pointer;
+		font-weight: 700;
+		border: none;
+	}
+	.modal-actions button.primary {
+		background: var(--brand-green);
+		color: var(--text-primary);
+	}
+	.qr-modal {
+		text-align: center;
+	}
+	.qr-modal img {
+		background: white;
+		padding: 1rem;
+		border-radius: 12px;
+		margin-top: 1rem;
+	}
 
-.qr-modal img {
-  background: white;
-  padding: 1rem;
-  border-radius: 12px;
-  margin-top: 1rem;
-}
+	/* Main Layout */
+	.mission-control {
+		display: flex;
+		flex-direction: column;
+		height: 100vh;
+		padding: 1.5rem;
+		gap: 1.5rem;
+	}
+	.setup-panel {
+		flex-shrink: 0;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		background: var(--bg-panel);
+		padding: 1rem 1.5rem;
+		border-radius: 1rem;
+		border: 1px solid var(--border-color);
+	}
+	.logo span {
+		font-family: var(--font-display);
+		font-size: 2rem;
+		color: var(--brand-yellow);
+		letter-spacing: 1px;
+	}
+	.setup-controls {
+		display: flex;
+		align-items: flex-end;
+		gap: 1.5rem;
+	}
+	.form-group label {
+		display: block;
+		margin-bottom: 0.25rem;
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+	}
+	.form-group input {
+		width: 80px;
+		font-size: 1rem;
+		padding: 0.5rem;
+		border-radius: 6px;
+		border: 1px solid var(--border-color);
+		background: var(--bg-main);
+		color: var(--text-primary);
+	}
+	.roster-btn {
+		height: 38px;
+		font-size: 1rem;
+		padding: 0.5rem 1rem;
+		border-radius: 6px;
+		border: 1px solid var(--border-color);
+		background: var(--bg-main);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-weight: 600;
+	}
+	.main-content {
+		flex-grow: 1;
+		display: grid;
+		grid-template-columns: 1.2fr 1fr;
+		gap: 1.5rem;
+		min-height: 0;
+	}
+
+	/* Left Panel */
+	.left-panel {
+		background: var(--bg-panel);
+		border-radius: 1rem;
+		border: 1px solid var(--border-color);
+		padding: 1.5rem;
+		overflow-y: auto;
+	}
+	.station-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+	}
+	.station-card {
+		background: var(--bg-main);
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		transition: all 200ms ease;
+	}
+	.station-card.current {
+		border-color: var(--brand-yellow);
+		box-shadow: 0 0 20px rgba(253, 224, 71, 0.2);
+		transform: scale(1.02);
+	}
+	.station-card__header {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.station-number {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		background: var(--bg-panel);
+		color: var(--text-muted);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		font-size: 0.9rem;
+		flex-shrink: 0;
+	}
+	.station-card.current .station-number {
+		background: var(--brand-yellow);
+		color: var(--bg-main);
+	}
+	.station-card h3 {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+	.shared-badge {
+		font-size: 0.7rem;
+		background: #3b82f6;
+		padding: 0.1rem 0.5rem;
+		border-radius: 999px;
+		margin-left: auto;
+	}
+	.station-card__tasks {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+	.task-line {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.85rem;
+	}
+	.task-label {
+		font-size: 0.7rem;
+		font-weight: 700;
+		color: var(--text-muted);
+	}
+	.task-text {
+		color: var(--text-secondary);
+	}
+	.station-card__roster {
+		margin-top: auto;
+		padding-top: 0.5rem;
+		border-top: 1px solid var(--border-color);
+	}
+	.roster-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+	}
+	.roster-chips span {
+		padding: 0.1rem 0.4rem;
+		border-radius: 4px;
+		background: var(--bg-panel);
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 600;
+	}
+	.roster-empty {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+	}
+
+	/* Right Panel */
+	.right-panel {
+		background: var(--bg-panel);
+		border-radius: 1rem;
+		border: 1px solid var(--border-color);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		padding: 2rem;
+	}
+	.timer-main {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		width: 100%;
+	}
+	.phase-display {
+		font-family: var(--font-display);
+		font-size: clamp(3rem, 10vw, 6rem);
+		letter-spacing: 4px;
+		line-height: 1;
+	}
+	.time-display {
+		font-family: var(--font-display);
+		font-size: clamp(10rem, 30vh, 20rem);
+		line-height: 1;
+		margin: 1rem 0;
+	}
+	.progress-bar-container {
+		width: 100%;
+		max-width: 700px;
+		height: 6px;
+		background: var(--bg-main);
+		border-radius: 999px;
+		overflow: hidden;
+	}
+	.progress-bar-fill {
+		height: 100%;
+		background: var(--brand-yellow);
+	}
+	.timer-footer {
+		width: 100%;
+		margin-top: auto;
+		padding-top: 1rem;
+	}
+	.meta-info {
+		display: flex;
+		justify-content: center;
+		gap: 2rem;
+		margin-bottom: 1rem;
+		color: var(--text-secondary);
+		font-size: 1.25rem;
+		font-family: var(--font-display);
+		letter-spacing: 1px;
+	}
+	.control-row {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+	}
+	.control-row button {
+		border-radius: 999px;
+		font-size: 1.25rem;
+		padding: 1rem 3rem;
+		cursor: pointer;
+		font-weight: 700;
+		border: none;
+	}
+	.control-row button.secondary {
+		background: var(--bg-panel);
+		color: var(--text-secondary);
+	}
+	.control-row button.primary {
+		background: var(--brand-green);
+		color: var(--text-primary);
+	}
+
+	@media (max-width: 1200px) {
+		.main-content {
+			grid-template-columns: 1.1fr 1fr;
+		}
+		.station-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+	@media (max-width: 900px) {
+		.mission-control {
+			padding: 1rem;
+		}
+		.main-content {
+			display: flex;
+			flex-direction: column;
+		}
+		.left-panel {
+			max-height: 50vh;
+		}
+		.setup-panel {
+			flex-direction: column;
+			gap: 1rem;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary
- rebuild the live timer page with a full mission control layout, persistent header controls, and QR modal support
- add roster rotation and attendee setup modals tailored to circuit and AMRAP workouts
- refresh timer presentation, station cards, and supporting styles for a polished experience

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e64e82e52c832f83c798e33bfb3221