### PR TITLE
Fix live session QR code link

### DIFF
--- a/workout-app/src/routes/timer/[id]/+page.js
+++ b/workout-app/src/routes/timer/[id]/+page.js
@@ -17,7 +17,7 @@ export async function load({ params, url }) {
                 return {
                         workout,
                         sessionId: params.id,
-                        url: { host: url.host }
+                        url: { origin: url.origin }
                 };
 	} else {
 		throw error(404, 'Workout not found');

--- a/workout-app/src/routes/timer/[id]/+page.svelte
+++ b/workout-app/src/routes/timer/[id]/+page.svelte
@@ -24,6 +24,7 @@ let timerId = null;
 let isSetupVisible = false;
 let showQr = false;
 let sessionId = null;
+let qrJoinUrl = '';
 
 // --- Staff Roster Logic ---
 let totalStations = workout.exercises?.length ?? 0;
@@ -58,6 +59,11 @@ limit(1)
 const sessionsSnapshot = await getDocs(sessionsQuery);
 if (!sessionsSnapshot.empty) { sessionId = sessionsSnapshot.docs[0].id; }
 });
+
+$: {
+    const baseOrigin = url?.origin ?? (typeof window !== 'undefined' ? window.location.origin : '');
+    qrJoinUrl = sessionId && baseOrigin ? `${baseOrigin}/live/${sessionId}` : '';
+}
 
 // --- Timer Core Functions ---
 function advancePhase() {
@@ -129,12 +135,12 @@ onDestroy(() => clearInterval(timerId));
 </div>
 {/if}
 
-{#if showQr && sessionId}
+{#if showQr && sessionId && qrJoinUrl}
 <div class="modal-overlay" on:click|self={() => showQr = false}>
 <div class="modal-content qr-modal">
 <h2>Scan to Join Live Session</h2>
 <p>Members can scan this with their phone to join.</p>
-<img src={`https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(`${url.origin}/live/${sessionId}`)}`} alt="QR Code to join session" />
+<img src={`https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=${encodeURIComponent(qrJoinUrl)}`} alt="QR Code to join session" />
 </div>
 </div>
 {/if}


### PR DESCRIPTION
## Summary
- ensure the timer page load function exposes the full origin instead of just the host
- derive a full join-session URL for the QR modal and guard against missing data
- update the QR code to encode the validated join URL so the link resolves correctly

## Testing
- npm run check *(fails: existing svelte-check errors and warnings in live session and admin components)*

------
https://chatgpt.com/codex/tasks/task_e_68e6680510d8832fa8b8ce177bc4fad2