### PR TITLE
Save session roster on start and rebuild member live tracker

### DIFF
--- a/workout-app/src/routes/live/[sessionId]/+page.svelte
+++ b/workout-app/src/routes/live/[sessionId]/+page.svelte
@@ -1,236 +1,182 @@
 <script>
-// @ts-nocheck
-import { onMount } from 'svelte';
-import { db } from '$lib/firebase';
-import { doc, onSnapshot, setDoc } from 'firebase/firestore';
-import { user } from '$lib/store';
+  // @ts-nocheck
+  import { onMount, onDestroy } from 'svelte';
+  import { db } from '$lib/firebase';
+  import { doc, onSnapshot, updateDoc, addDoc, serverTimestamp, collection } from 'firebase/firestore';
+  import { user } from '$lib/store';
 
-export let data;
-const { session, workout } = data;
-let myScore = 0;
-let userProfile = {};
+  export let data;
+  const { session, workout } = data;
 
-let liveState = { phase: 'Connecting...', remaining: 0, currentStation: 0, isRunning: false, movesCompleted: 0 };
-let myCurrentStationIndex = -1;
-let hasSyncedProfile = false;
+  // This holds the live state broadcast from the admin's timer
+  let liveState = { phase: 'Connecting...', remaining: 0, currentStation: 0, movesCompleted: 0 };
+  
+  let userProfile = {};
+  let myCurrentStationIndex = -1;
+  let myNextStationIndex = -1;
+  let hasSavedFinalScore = false;
 
-onMount(() => {
-const userUid = $user?.uid;
-if (!userUid) return;
+  // This now holds a structured score for every station in the workout
+  let liveScores = workout.exercises.map(ex => ({
+    stationName: ex.name,
+    category: ex.category,
+    score: { reps: 0, weight: 0, cals: 0, dist: '' }
+  }));
+  
+  let unsubscribe = [];
 
-const profileRef = doc(db, 'profiles', userUid);
-const unsubscribeProfile = onSnapshot(profileRef, (docSnap) => {
-if (docSnap.exists()) {
-userProfile = docSnap.data();
-}
-});
+  onMount(() => {
+    const userUid = $user?.uid;
+    if (!userUid) return;
 
-const liveStateRef = doc(db, 'sessions', session.id, 'liveState', 'data');
-const unsubscribeState = onSnapshot(liveStateRef, (docSnap) => {
-if (docSnap.exists()) {
-liveState = docSnap.data();
-}
-});
+    // Get user's profile to find their name
+    const profileRef = doc(db, 'profiles', userUid);
+    const unsubProfile = onSnapshot(profileRef, (doc) => { if (doc.exists()) { userProfile = doc.data(); } });
 
-const myScoreRef = doc(db, 'sessions', session.id, 'attendees', userUid);
-const unsubscribeScore = onSnapshot(myScoreRef, async (docSnap) => {
-if (docSnap.exists()) {
-myScore = docSnap.data().score || 0;
-} else if (userProfile?.displayName) {
-await setDoc(myScoreRef, { displayName: userProfile.displayName, score: 0 }, { merge: true });
-}
-});
+    // Listen for live state updates from the admin timer
+    const liveStateRef = doc(db, 'sessions', session.id, 'liveState', 'data');
+    const unsubState = onSnapshot(liveStateRef, (doc) => {
+      if (doc.exists()) {
+        liveState = doc.data();
+        // When the workout is complete, trigger the final save
+        if (liveState.isComplete && !hasSavedFinalScore) {
+          saveFinalScores();
+        }
+      }
+    });
+    
+    unsubscribe = [unsubProfile, unsubState];
+    return () => unsubscribe.forEach(unsub => unsub());
+  });
+  
+  async function updateLiveScore() {
+    const userUid = $user?.uid;
+    if (!userUid) return;
+    const myScoreRef = doc(db, 'sessions', session.id, 'attendees', userUid);
+    await updateDoc(myScoreRef, { 
+      score: liveScores[myCurrentStationIndex].score 
+    });
+  }
 
-return () => {
-unsubscribeProfile?.();
-unsubscribeState?.();
-unsubscribeScore?.();
-};
-});
+  async function saveFinalScores() {
+    if (hasSavedFinalScore) return;
+    hasSavedFinalScore = true;
+    
+    const cleanedScores = liveScores.filter(item => 
+      item.score.reps > 0 || item.score.weight > 0 || item.score.cals > 0 || item.score.dist.trim() !== ''
+    );
 
-async function incrementScore() {
-const userUid = $user?.uid;
-if (!userUid) return;
+    if (cleanedScores.length === 0) return; // Don't save if no scores were entered
 
-const newScore = myScore + 1;
-const myScoreRef = doc(db, 'sessions', session.id, 'attendees', userUid);
+    await addDoc(collection(db, 'scores'), {
+      userId: $user.uid,
+      displayName: userProfile.displayName,
+      workoutId: workout.id,
+      workoutTitle: workout.title,
+      date: serverTimestamp(),
+      exerciseScores: cleanedScores
+    });
+  }
 
-await setDoc(myScoreRef, { score: newScore }, { merge: true });
-}
+  // This reactive block calculates the user's current and next station
+  $: if (userProfile.displayName && session.stationAssignments && liveState.movesCompleted !== undefined) {
+    let myStartingIndex = -1;
+    session.stationAssignments.forEach((roster, index) => {
+      if (roster.includes(userProfile.displayName.toUpperCase())) {
+        myStartingIndex = index;
+      }
+    });
 
-function formatTime(s) {
-const secs = Math.max(0, Math.ceil(s));
-return String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0');
-}
-
-$: {
-if (userProfile.displayName && Array.isArray(session.stationAssignments) && workout.exercises?.length) {
-let myStartingIndex = -1;
-
-session.stationAssignments.forEach((roster, index) => {
-if (Array.isArray(roster) && roster.includes(userProfile.displayName.toUpperCase())) {
-myStartingIndex = index;
-}
-});
-
-if (myStartingIndex !== -1 && typeof liveState.movesCompleted === 'number') {
-myCurrentStationIndex = (myStartingIndex + liveState.movesCompleted) % workout.exercises.length;
-} else {
-myCurrentStationIndex = myStartingIndex;
-}
-} else {
-myCurrentStationIndex = -1;
-}
-}
-
-$: if (!hasSyncedProfile && userProfile.displayName && $user?.uid) {
-const attendeeRef = doc(db, 'sessions', session.id, 'attendees', $user.uid);
-setDoc(attendeeRef, { displayName: userProfile.displayName }, { merge: true });
-hasSyncedProfile = true;
-}
-
-$: myStationData = myCurrentStationIndex !== -1 && workout.exercises ? workout.exercises[myCurrentStationIndex] : null;
+    if (myStartingIndex !== -1) {
+      const totalStations = workout.exercises.length;
+      myCurrentStationIndex = (myStartingIndex + liveState.movesCompleted) % totalStations;
+      myNextStationIndex = (myCurrentStationIndex + 1) % totalStations;
+    }
+  }
+  
+  $: myStationData = myCurrentStationIndex !== -1 ? workout.exercises[myCurrentStationIndex] : null;
+  $: nextStationData = myNextStationIndex !== -1 ? workout.exercises[myNextStationIndex] : null;
+  
+  function formatTime(s) { const secs = Math.max(0, Math.ceil(s)); return (String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0')); }
 </script>
 
 <div class="tracker-container">
-<header class="tracker-header">
-<h1>{liveState.phase}</h1>
-<div class="main-time">{formatTime(liveState.remaining)}</div>
-</header>
+  <header class="tracker-header">
+    <h1>{liveState.phase}</h1>
+    <div class="main-time">{formatTime(liveState.remaining)}</div>
+  </header>
 
-<main class="tracker-main">
-<div class="score-card">
-<span class="score-label">Your Score</span>
-<span class="score-value">{myScore}</span>
-</div>
-<button class="add-btn" on:click={incrementScore} disabled={!liveState.isRunning}>+</button>
-</main>
+  {#if myStationData}
+    <main class="tracker-main">
+      <div class="score-card">
+        <span class="score-label">My Score</span>
+        {#if myStationData.category === 'Resistance'}
+          <div class="input-row">
+            <input type="number" placeholder="Reps" bind:value={liveScores[myCurrentStationIndex].score.reps} on:change={updateLiveScore} />
+            <input type="number" placeholder="kg" bind:value={liveScores[myCurrentStationIndex].score.weight} on:change={updateLiveScore} />
+          </div>
+        {:else if myStationData.category === 'Cardio Machine'}
+          <div class="input-row">
+            <input type="number" placeholder="Cals" bind:value={liveScores[myCurrentStationIndex].score.cals} on:change={updateLiveScore} />
+            <input type="text" placeholder="Dist" bind:value={liveScores[myCurrentStationIndex].score.dist} on:change={updateLiveScore} />
+          </div>
+        {:else}
+          <div class="input-row single">
+            <button on:click={() => { liveScores[myCurrentStationIndex].score.reps--; updateLiveScore(); }}>-</button>
+            <span class="score-value">{liveScores[myCurrentStationIndex].score.reps || 0}</span>
+            <button on:click={() => { liveScores[myCurrentStationIndex].score.reps++; updateLiveScore(); }}>+</button>
+          </div>
+          <span class="score-label">Reps</span>
+        {/if}
+      </div>
+    </main>
 
-<footer class="station-info">
-{#if myStationData}
-<h2>Station {myCurrentStationIndex + 1}: {myStationData.name}</h2>
-<div class="task-line">
-<span class="task-label p1">P1</span>
-<span class="task-text">{myStationData.p1?.task || myStationData.p1_task || myStationData.name}</span>
-</div>
-{#if myStationData.p2?.task || myStationData.p2_task}
-<div class="task-line">
-<span class="task-label p2">P2</span>
-<span class="task-text">{myStationData.p2?.task || myStationData.p2_task}</span>
-</div>
-{/if}
-{:else}
-<h2>Waiting for admin to start session...</h2>
-{/if}
-</footer>
+    <footer class="station-info">
+      <div class="station-display current">
+        <h2>NOW: {myStationData.name}</h2>
+        <div class="task-line"><span class="task-label p1">P1</span><span class="task-text">{myStationData.p1?.task}</span></div>
+        {#if myStationData.p2?.task}<div class="task-line"><span class="task-label p2">P2</span><span class="task-text">{myStationData.p2.task}</span></div>{/if}
+      </div>
+      {#if nextStationData}
+      <div class="station-display next">
+        <h2>NEXT: {nextStationData.name}</h2>
+        <div class="task-line"><span class="task-label p1">P1</span><span class="task-text">{nextStationData.p1?.task}</span></div>
+        {#if nextStationData.p2?.task}<div class="task-line"><span class="task-label p2">P2</span><span class="task-text">{nextStationData.p2.task}</span></div>{/if}
+      </div>
+      {/if}
+    </footer>
+  {:else}
+    <main class="tracker-main">
+      <div class="waiting-message">Waiting for admin to start session...</div>
+    </main>
+  {/if}
 </div>
 
 <style>
-.tracker-container {
-display: flex;
-flex-direction: column;
-height: 100vh;
-background: var(--deep-space);
-padding: 1.5rem;
-text-align: center;
-}
-.tracker-header {
-flex-shrink: 0;
-}
-h1 {
-font-family: var(--font-display);
-font-size: 2.5rem;
-color: var(--text-secondary);
-letter-spacing: 2px;
-}
-.main-time {
-font-family: var(--font-display);
-font-size: 4rem;
-color: var(--brand-yellow);
-line-height: 1;
-}
-.tracker-main {
-flex-grow: 1;
-display: flex;
-flex-direction: column;
-align-items: center;
-justify-content: center;
-gap: 1.5rem;
-}
-.score-card {
-background: var(--surface-1);
-border-radius: 50%;
-width: 180px;
-height: 180px;
-display: flex;
-flex-direction: column;
-align-items: center;
-justify-content: center;
-border: 1px solid var(--border-color);
-}
-.score-label {
-font-size: 0.9rem;
-color: var(--text-muted);
-}
-.score-value {
-font-family: var(--font-display);
-font-size: 5rem;
-line-height: 1;
-}
-.add-btn {
-background: var(--brand-green);
-color: var(--text-primary);
-width: 100px;
-height: 100px;
-border-radius: 50%;
-border: none;
-font-size: 4rem;
-font-weight: 200;
-cursor: pointer;
-display: flex;
-align-items: center;
-justify-content: center;
-padding-bottom: 0.5rem;
-}
-.station-info {
-flex-shrink: 0;
-background: var(--surface-1);
-border: 1px solid var(--border-color);
-border-radius: 16px;
-padding: 1rem;
-text-align: left;
-}
-.station-info h2 {
-font-size: 1.2rem;
-margin-bottom: 0.75rem;
-}
-.task-line {
-display: flex;
-align-items: center;
-gap: 0.5rem;
-font-size: 0.9rem;
-margin-bottom: 0.5rem;
-}
-.task-label {
-width: 24px;
-height: 24px;
-border-radius: 50%;
-font-size: 0.65rem;
-font-weight: 700;
-flex-shrink: 0;
-display: inline-flex;
-align-items: center;
-justify-content: center;
-}
-.task-label.p1 {
-background: #34d39933;
-color: #34d399;
-}
-.task-label.p2 {
-background: #f472b633;
-color: #f472b6;
-}
-.task-text {
-color: var(--text-secondary);
-}
+  .tracker-container { display: flex; flex-direction: column; height: 100vh; background: var(--deep-space); padding: 1.5rem; text-align: center; gap: 1rem; }
+  .tracker-header { flex-shrink: 0; }
+  h1 { font-family: var(--font-display); font-size: 2.5rem; color: var(--text-secondary); letter-spacing: 2px; }
+  .main-time { font-family: var(--font-display); font-size: 4rem; color: var(--brand-yellow); line-height: 1; }
+  .tracker-main { flex-grow: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1rem; }
+  .score-card { background: var(--surface-1); width: 100%; max-width: 350px; padding: 1.5rem; border-radius: 16px; }
+  .score-label { font-size: 0.9rem; color: var(--text-muted); text-transform: uppercase; }
+  .input-row { display: flex; gap: 0.5rem; align-items: center; justify-content: center; margin-top: 0.5rem; }
+  .input-row input { font-size: 2rem; width: 100%; text-align: center; background: var(--deep-space); border: 1px solid var(--border-color); color: var(--text-primary); border-radius: 8px; padding: 0.5rem; }
+  .input-row.single { justify-content: space-around; }
+  .score-value { font-family: var(--font-display); font-size: 5rem; line-height: 1; }
+  .input-row button { background: var(--brand-green); color: var(--text-primary); width: 60px; height: 60px; border-radius: 50%; border: none; font-size: 2.5rem; }
+  .station-info { flex-shrink: 0; display: flex; flex-direction: column; gap: 1rem; }
+  .station-display { background: var(--surface-1); border: 1px solid var(--border-color); border-radius: 16px; padding: 1rem; text-align: left; }
+  .station-display.current { border-left: 4px solid var(--brand-yellow); }
+  .station-display.next { opacity: 0.6; }
+  .station-info h2 { font-size: 1.1rem; margin-bottom: 0.75rem; }
+  .task-line { display: flex; align-items: center; gap: 0.5rem; }
+  .task-label { width: 22px; height: 22px; border-radius: 50%; font-size: 0.6rem; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; }
+  .task-label.p1 { background: #34d39933; color: #34d399; }
+  .task-label.p2 { background: #f472b633; color: #f472b6; }
+  .waiting-message { font-size: 1.2rem; color: var(--text-muted); }
 </style>
+
+
+
+


### PR DESCRIPTION
## Summary
- persist the station roster to the session document the moment the admin timer starts so member devices know their assignments
- rebuild the live member tracker UI to show current/next stations, contextual score inputs, and automatically log final workout scores

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67a634bcc832f8f4f4fca07f22e6e