### PR TITLE
Add missing closing div for live session layout

### DIFF
--- a/workout-app/src/routes/live/[sessionId]/+page.svelte
+++ b/workout-app/src/routes/live/[sessionId]/+page.svelte
@@ -1942,6 +1942,7 @@ function formatTime(s) {
                 </div>
         {/if}
 </div>
+</div>
 
 
 


### PR DESCRIPTION
## Summary
- close the live session tracker layout container to resolve the Vercel/Svelte unclosed element error

## Testing
- npm run build *(fails due to missing Firebase configuration: auth/invalid-api-key)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402ae977fc832f915b2affb35c5858)