### PR TITLE
Modernize workout app UI and coach dashboard

### DIFF
--- a/workout-app/src/app.css
+++ b/workout-app/src/app.css
@@ -1,28 +1,37 @@
 /* src/app.css */
 :root {
-        --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        --font-display: 'Bebas Neue', 'Arial Narrow', sans-serif;
-        --brand-yellow: #fde047;
-        --brand-green: #16a34a;
-        --deep-space: #0f172a;
-        --bg-main: #0f172a;
-        --bg-panel: #111c32;
-        --surface-1: rgba(255, 255, 255, 0.06);
-        --surface-2: rgba(255, 255, 255, 0.08);
-        --surface-3: rgba(255, 255, 255, 0.12);
-        --border-color: rgba(255, 255, 255, 0.08);
-        --text-primary: #f9fafb;
-        --text-secondary: #cbd5f5;
-        --text-muted: #94a3b8;
-        --error: #ef4444;
-        --transition: 150ms ease;
+	--font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	--font-display: 'Bebas Neue', 'Inter', sans-serif;
+	--brand-yellow: #facc15;
+	--brand-yellow-strong: #f59e0b;
+	--brand-green: #22c55e;
+	--brand-green-strong: #16a34a;
+	--brand-blue: #38bdf8;
+	--deep-space: #07111f;
+	--bg-main: #07111f;
+	--bg-panel: rgba(15, 23, 42, 0.82);
+	--surface-1: rgba(255, 255, 255, 0.07);
+	--surface-2: rgba(255, 255, 255, 0.11);
+	--surface-3: rgba(255, 255, 255, 0.16);
+	--border-color: rgba(226, 232, 240, 0.14);
+	--text-primary: #f8fafc;
+	--text-secondary: #dbeafe;
+	--text-muted: #94a3b8;
+	--error: #fb7185;
+	--success: #4ade80;
+	--shadow-soft: 0 24px 80px rgba(0, 0, 0, 0.34);
+	--shadow-card: 0 18px 50px rgba(0, 0, 0, 0.28);
+	--radius-xl: 28px;
+	--radius-lg: 20px;
+	--radius-md: 14px;
+	--transition: 180ms ease;
 
-        /* Legacy aliases used across existing components */
-        --bg: var(--bg-main);
-        --card: var(--bg-panel);
-        --text: var(--text-primary);
-        --yellow: var(--brand-yellow);
-        --green: var(--brand-green);
+	/* Legacy aliases used across existing components */
+	--bg: var(--bg-main);
+	--card: var(--bg-panel);
+	--text: var(--text-primary);
+	--yellow: var(--brand-yellow);
+	--green: var(--brand-green);
 }
 
 * {
@@ -31,52 +40,138 @@
 	padding: 0;
 }
 
+html {
+	background: var(--bg-main);
+}
+
 body {
-        font-family: var(--font-body);
-        background-color: var(--bg);
-        color: var(--text);
-        min-height: 100vh;
-        line-height: 1.5;
+	font-family: var(--font-body);
+	background:
+		radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 34rem),
+		radial-gradient(circle at 85% 10%, rgba(250, 204, 21, 0.16), transparent 26rem),
+		linear-gradient(135deg, #07111f 0%, #0f172a 52%, #111827 100%);
+	background-attachment: fixed;
+	color: var(--text);
+	min-height: 100vh;
+	line-height: 1.5;
+	accent-color: var(--brand-yellow);
+}
+
+body::before {
+	position: fixed;
+	inset: 0;
+	z-index: -1;
+	pointer-events: none;
+	content: '';
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+	background-size: 44px 44px;
+	mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.68), transparent 76%);
 }
 
 a {
 	color: inherit;
 }
 
+button,
+input,
+select,
+textarea {
+	font: inherit;
+}
+
+button {
+	border: 0;
+}
+
 .app-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: flex-start;
-        min-height: 100vh;
-        padding: clamp(1rem, 4vw, 2.5rem);
-        gap: 1.5rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+	min-height: 100vh;
+	padding: clamp(1rem, 4vw, 2.5rem);
+	gap: 1.5rem;
+}
+
+.loading-shell {
+	display: grid;
+	width: min(560px, 100%);
+	min-height: 45vh;
+	place-items: center;
+	text-align: center;
+}
+
+.loading-card {
+	width: 100%;
+	padding: 2rem;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-xl);
+	background: rgba(15, 23, 42, 0.76);
+	box-shadow: var(--shadow-card);
+	backdrop-filter: blur(18px);
+}
+
+.loading-pulse {
+	display: inline-flex;
+	width: 3rem;
+	height: 3rem;
+	margin-bottom: 1rem;
+	border-radius: 999px;
+	background: linear-gradient(135deg, var(--brand-yellow), var(--brand-green));
+	box-shadow: 0 0 38px rgba(250, 204, 21, 0.45);
+	animation: pulse 1.2s ease-in-out infinite;
 }
 
 .auth-page {
+	display: grid;
 	width: 100%;
-	max-width: 400px;
+	max-width: 1080px;
+	min-height: min(760px, calc(100vh - 5rem));
+	place-items: center;
 }
 
 .auth-card {
-	background-color: var(--card);
+	position: relative;
+	overflow: hidden;
+	width: min(460px, 100%);
 	border: 1px solid var(--border-color);
-	border-radius: 16px;
-	padding: 2rem;
-	text-align: center;
-	box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+	border-radius: var(--radius-xl);
+	padding: clamp(1.6rem, 4vw, 2.4rem);
+	text-align: left;
+	background: linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(17, 24, 39, 0.78));
+	box-shadow: var(--shadow-soft);
+	backdrop-filter: blur(22px);
+}
+
+.auth-card::before {
+	position: absolute;
+	top: -35%;
+	right: -28%;
+	width: 16rem;
+	height: 16rem;
+	border-radius: 999px;
+	content: '';
+	background: rgba(250, 204, 21, 0.15);
+	filter: blur(2px);
 }
 
 .auth-card h1 {
-	color: var(--yellow);
-	margin-bottom: 0.5rem;
-	font-size: 1.75rem;
+	position: relative;
+	margin-bottom: 0.4rem;
+	color: var(--text-primary);
+	font-family: var(--font-display);
+	font-size: clamp(2.3rem, 9vw, 4rem);
+	letter-spacing: 0.04em;
+	line-height: 0.95;
 }
 
 .auth-card p {
-	color: var(--text-muted);
+	position: relative;
 	margin-bottom: 1.5rem;
-	font-size: 0.95rem;
+	color: var(--text-muted);
+	font-size: 0.98rem;
 }
 
 .auth-card strong {
@@ -97,92 +192,112 @@ form {
 .form-group label {
 	display: block;
 	margin-bottom: 0.5rem;
-	font-size: 0.9rem;
 	color: var(--text-muted);
+	font-size: 0.78rem;
+	font-weight: 800;
 	text-transform: uppercase;
-	letter-spacing: 0.04em;
+	letter-spacing: 0.08em;
 }
 
-.form-group input {
+.form-group input,
+.form-group select,
+.form-group textarea,
+input[type='search'],
+select,
+textarea {
 	width: 100%;
-	background-color: var(--bg);
 	border: 1px solid var(--border-color);
-	border-radius: 8px;
+	border-radius: var(--radius-md);
 	color: var(--text);
-	padding: 0.75rem;
+	background: rgba(2, 6, 23, 0.48);
+	padding: 0.85rem 0.95rem;
 	font-size: 1rem;
 	transition:
 		box-shadow var(--transition),
 		outline var(--transition),
-		border-color var(--transition);
+		border-color var(--transition),
+		background-color var(--transition);
 }
 
-.form-group input::placeholder {
-	color: rgba(230, 230, 230, 0.5);
+.form-group input::placeholder,
+input[type='search']::placeholder,
+textarea::placeholder {
+	color: rgba(226, 232, 240, 0.45);
 }
 
-.form-group input:focus {
-	outline: 2px solid var(--yellow);
-	border-color: transparent;
-	box-shadow: 0 0 0 4px rgba(255, 214, 10, 0.15);
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus,
+input[type='search']:focus,
+select:focus,
+textarea:focus {
+	border-color: rgba(250, 204, 21, 0.6);
+	outline: 2px solid rgba(250, 204, 21, 0.18);
+	box-shadow: 0 0 0 5px rgba(250, 204, 21, 0.1);
+	background: rgba(2, 6, 23, 0.7);
 }
 
 .primary-btn,
 .secondary-btn {
-	display: inline-block;
+	display: inline-flex;
 	width: 100%;
-	border-radius: 8px;
-	padding: 0.75rem 1rem;
+	align-items: center;
+	justify-content: center;
+	border-radius: var(--radius-md);
+	padding: 0.82rem 1rem;
 	font-size: 1rem;
-	font-weight: 600;
+	font-weight: 800;
 	cursor: pointer;
 	margin-top: 1rem;
 	text-decoration: none;
 	transition:
 		transform var(--transition),
 		box-shadow var(--transition),
-		background-color var(--transition);
+		background-color var(--transition),
+		border-color var(--transition);
 }
 
 .primary-btn {
-        background-color: var(--brand-green);
-        color: var(--text-primary);
-        border: 1px solid rgba(15, 58, 42, 0.6);
-        box-shadow: 0 10px 25px rgba(22, 163, 74, 0.35);
+	border: 1px solid rgba(250, 204, 21, 0.26);
+	background: linear-gradient(135deg, var(--brand-yellow), var(--brand-green));
+	color: #08111f;
+	box-shadow: 0 16px 35px rgba(34, 197, 94, 0.24);
 }
 
 .primary-btn:hover,
 .primary-btn:focus-visible {
-        background-color: #22c55e;
-        transform: translateY(-2px);
+	transform: translateY(-2px);
+	box-shadow: 0 20px 45px rgba(34, 197, 94, 0.34);
 }
 
 .secondary-btn {
-        background: var(--surface-1);
-        color: var(--text-secondary);
-        border: 1px solid var(--border-color);
+	border: 1px solid var(--border-color);
+	background: rgba(255, 255, 255, 0.08);
+	color: var(--text-secondary);
 }
 
 .secondary-btn:hover,
 .secondary-btn:focus-visible {
-	background: #15201a;
 	transform: translateY(-1px);
+	border-color: rgba(250, 204, 21, 0.34);
+	background: rgba(255, 255, 255, 0.13);
 }
 
 .link-btn {
 	background: none;
 	border: none;
-	color: var(--yellow);
+	color: var(--brand-yellow);
 	text-decoration: underline;
 	cursor: pointer;
 	font-size: inherit;
+	font-weight: 800;
 	padding: 0;
 	margin-left: 0.5rem;
 }
 
 .link-btn:hover,
 .link-btn:focus-visible {
-	color: #ffe169;
+	color: #fde68a;
 }
 
 .error-message {
@@ -195,26 +310,39 @@ form {
 button:focus-visible,
 .link-btn:focus-visible,
 .primary-btn:focus-visible,
-.secondary-btn:focus-visible {
-	outline: 2px solid var(--yellow);
-	outline-offset: 2px;
+.secondary-btn:focus-visible,
+a:focus-visible {
+	outline: 2px solid var(--brand-yellow);
+	outline-offset: 3px;
 }
 
 button:disabled,
 .primary-btn:disabled,
 .secondary-btn:disabled {
-	opacity: 0.6;
+	opacity: 0.62;
 	cursor: not-allowed;
 	transform: none;
 	box-shadow: none;
 }
 
-@media (max-width: 480px) {
-	.auth-card {
-		padding: 1.75rem 1.5rem;
+@keyframes pulse {
+	0%,
+	100% {
+		transform: scale(0.95);
+		opacity: 0.72;
+	}
+	50% {
+		transform: scale(1.05);
+		opacity: 1;
+	}
+}
+
+@media (max-width: 640px) {
+	.app-container {
+		padding: 1rem;
 	}
 
-	.auth-card h1 {
-		font-size: 1.5rem;
+	.auth-card {
+		border-radius: 22px;
 	}
 }

--- a/workout-app/src/lib/components/AdminNav.svelte
+++ b/workout-app/src/lib/components/AdminNav.svelte
@@ -1,147 +1,251 @@
 <script>
-        import { onDestroy } from 'svelte';
-        import { page } from '$app/stores';
+	import { onDestroy } from 'svelte';
+	import { page } from '$app/stores';
+	import { resolve } from '$app/paths';
 
-        let isOpen = false;
-        let lastPathname = '';
+	let isOpen = false;
+	let lastPathname = '';
 
-        const stopWatchingPage = page.subscribe(($page) => {
-                if (lastPathname && lastPathname !== $page.url.pathname) {
-                        isOpen = false;
-                }
-                lastPathname = $page.url.pathname;
-        });
+	const navItems = [
+		{ path: '/dashboard', href: resolve('/dashboard'), label: 'Dashboard', icon: '⌁' },
+		{ path: '/admin/workouts', href: resolve('/admin/workouts'), label: 'Workouts', icon: '▦' },
+		{ path: '/admin/create', href: resolve('/admin/create'), label: 'Create', icon: '+' },
+		{ path: '/admin/sessions', href: resolve('/admin/sessions'), label: 'Sessions', icon: '◷' },
+		{ path: '/admin/attendance', href: resolve('/admin/attendance'), label: 'Check-in', icon: '✓' }
+	];
 
-        onDestroy(() => {
-                stopWatchingPage();
-        });
+	const stopWatchingPage = page.subscribe(($page) => {
+		if (lastPathname && lastPathname !== $page.url.pathname) {
+			isOpen = false;
+		}
+		lastPathname = $page.url.pathname;
+	});
 
-        function toggleMenu() {
-                isOpen = !isOpen;
-        }
+	onDestroy(() => {
+		stopWatchingPage();
+	});
 
-        function closeMenu() {
-                isOpen = false;
-        }
+	function toggleMenu() {
+		isOpen = !isOpen;
+	}
 
-        /** @param {KeyboardEvent} event */
-        function handleKeydown(event) {
-                if (event.key === 'Escape') {
-                        event.preventDefault();
-                        closeMenu();
-                }
-        }
+	function closeMenu() {
+		isOpen = false;
+	}
+
+	/** @param {KeyboardEvent} event */
+	function handleKeydown(event) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			closeMenu();
+		}
+	}
 </script>
 
+<svelte:window on:keydown={handleKeydown} />
+
 <div class="admin-nav">
-        <button
-                class="hamburger"
-                on:click={toggleMenu}
-                on:keydown={handleKeydown}
-                aria-label="Toggle admin navigation"
-                aria-expanded={isOpen}
-        >
-                <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-			viewBox="0 0 24 24"
-			stroke-width="2"
-			stroke="currentColor"
-		>
-			<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-		</svg>
+	<a class="brand-pill" href={resolve('/dashboard')} aria-label="Coach dashboard">
+		<span class="brand-mark">C</span>
+		<span class="brand-copy">Coach</span>
+	</a>
+
+	<nav class="desktop-menu" aria-label="Admin quick links">
+		{#each navItems as item (item.path)}
+			<a
+				href={resolve(/** @type {any} */ (item.path))}
+				class:active={$page.url.pathname.startsWith(item.path)}
+			>
+				<span>{item.icon}</span>
+				{item.label}
+			</a>
+		{/each}
+	</nav>
+
+	<button
+		class="hamburger"
+		on:click={toggleMenu}
+		aria-label="Toggle admin navigation"
+		aria-expanded={isOpen}
+	>
+		<span></span>
+		<span></span>
+		<span></span>
 	</button>
 
-        {#if isOpen}
-                <button type="button" class="menu-overlay" aria-label="Close admin navigation" on:click={closeMenu}></button>
-                <nav class="menu" aria-label="Admin">
-                        <h3>Admin Menu</h3>
-                        <ul>
-                                <li><a href="/dashboard" on:click={closeMenu}>Dashboard</a></li>
-                                <li><a href="/admin/workouts" on:click={closeMenu}>My Workouts</a></li>
-                                <li><a href="/admin/create" on:click={closeMenu}>Create Workout</a></li>
-                                <li><a href="/admin/sessions" on:click={closeMenu}>Manage Sessions</a></li>
-                                <li><a href="/admin/attendance" on:click={closeMenu}>Member Check-in</a></li>
-                        </ul>
-                </nav>
-        {/if}
+	{#if isOpen}
+		<button
+			type="button"
+			class="menu-overlay"
+			aria-label="Close admin navigation"
+			on:click={closeMenu}
+		></button>
+		<nav class="mobile-menu" aria-label="Admin">
+			<p class="eyebrow">Admin Menu</p>
+			{#each navItems as item (item.path)}
+				<a
+					href={resolve(/** @type {any} */ (item.path))}
+					class:active={$page.url.pathname.startsWith(item.path)}
+					on:click={closeMenu}
+				>
+					<span>{item.icon}</span>
+					{item.label}
+				</a>
+			{/each}
+		</nav>
+	{/if}
 </div>
 
 <style>
 	.admin-nav {
-		position: fixed;
-		top: 1.5rem;
-		left: 1.5rem;
-		z-index: 50; /* Ensures the button is on top of page content */
-	}
-	.hamburger {
-		background: rgba(31, 41, 55, 0.7); /* Semi-transparent background */
-		border: 1px solid var(--border-color);
-		border-radius: 50%;
-		width: 48px;
-		height: 48px;
-		color: var(--text-secondary);
-		cursor: pointer;
-		backdrop-filter: blur(8px); /* Frosted glass effect */
+		position: sticky;
+		top: 1rem;
+		z-index: 50;
 		display: flex;
+		width: min(1180px, calc(100vw - 2rem));
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin: 1rem auto 0;
+		padding: 0.55rem;
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		background: rgba(15, 23, 42, 0.72);
+		box-shadow: 0 18px 60px rgba(0, 0, 0, 0.25);
+		backdrop-filter: blur(18px);
+	}
+
+	.brand-pill,
+	.desktop-menu a,
+	.mobile-menu a {
+		display: inline-flex;
+		align-items: center;
+		text-decoration: none;
+	}
+
+	.brand-pill {
+		gap: 0.55rem;
+		padding: 0.35rem 0.75rem 0.35rem 0.4rem;
+		border-radius: 999px;
+		color: var(--text-primary);
+		font-weight: 900;
+	}
+
+	.brand-mark {
+		display: grid;
+		width: 2.2rem;
+		height: 2.2rem;
+		place-items: center;
+		border-radius: 999px;
+		background: linear-gradient(135deg, var(--brand-yellow), var(--brand-green));
+		color: #07111f;
+		font-weight: 900;
+	}
+
+	.brand-copy {
+		letter-spacing: 0.02em;
+	}
+
+	.desktop-menu {
+		display: flex;
+		gap: 0.35rem;
+	}
+
+	.desktop-menu a,
+	.mobile-menu a {
+		gap: 0.45rem;
+		border-radius: 999px;
+		color: var(--text-secondary);
+		font-size: 0.92rem;
+		font-weight: 800;
+		transition:
+			background var(--transition),
+			color var(--transition),
+			transform var(--transition);
+	}
+
+	.desktop-menu a {
+		padding: 0.65rem 0.85rem;
+	}
+
+	.desktop-menu a:hover,
+	.desktop-menu a.active,
+	.mobile-menu a:hover,
+	.mobile-menu a.active {
+		background: rgba(255, 255, 255, 0.11);
+		color: var(--text-primary);
+	}
+
+	.hamburger {
+		display: none;
+		width: 2.6rem;
+		height: 2.6rem;
 		align-items: center;
 		justify-content: center;
-		transition: background-color 0.2s ease;
-	}
-	.hamburger:hover {
-		background: rgba(55, 65, 81, 0.8);
-	}
-	.hamburger svg {
-		width: 24px;
-		height: 24px;
-	}
-        .menu-overlay {
-                position: fixed;
-                inset: 0;
-                z-index: 48; /* Below the menu, above the page */
-                background: transparent;
-                border: none;
-                cursor: pointer;
-        }
-	.menu {
-		position: absolute;
-		top: 60px;
-		left: 0;
-		background: var(--surface-1); /* This provides the solid background */
-		border: 1px solid var(--border-color);
-		border-radius: 12px;
-		padding: 1rem;
-		width: 280px;
-		box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-		z-index: 49; /* Ensures menu is on top of the overlay */
-	}
-	.menu h3 {
-		font-family: var(--font-display);
-		font-size: 1.25rem;
-		letter-spacing: 1px;
-		margin: 0 0.5rem 1rem 0.5rem;
-		padding-bottom: 0.75rem;
-		border-bottom: 1px solid var(--border-color);
-		color: var(--brand-yellow);
-	}
-	.menu ul {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
-	}
-	.menu a {
-		display: block;
-		padding: 0.75rem 1rem;
-		text-decoration: none;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.1);
 		color: var(--text-secondary);
-		border-radius: 8px;
-		font-weight: 600;
+		cursor: pointer;
 	}
-	.menu a:hover {
-		background: var(--surface-2);
-		color: var(--text-primary);
+
+	.hamburger span {
+		width: 1.1rem;
+		height: 2px;
+		border-radius: 999px;
+		background: currentColor;
+	}
+
+	.menu-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 48;
+		background: rgba(2, 6, 23, 0.4);
+		cursor: pointer;
+	}
+
+	.mobile-menu {
+		position: absolute;
+		top: calc(100% + 0.65rem);
+		right: 0;
+		z-index: 49;
+		display: grid;
+		width: min(320px, calc(100vw - 2rem));
+		gap: 0.35rem;
+		padding: 1rem;
+		border: 1px solid var(--border-color);
+		border-radius: 24px;
+		background: rgba(15, 23, 42, 0.96);
+		box-shadow: var(--shadow-card);
+	}
+
+	.mobile-menu a {
+		padding: 0.9rem 1rem;
+	}
+
+	.eyebrow {
+		padding: 0 0.7rem 0.45rem;
+		color: var(--brand-yellow);
+		font-size: 0.74rem;
+		font-weight: 900;
+		text-transform: uppercase;
+		letter-spacing: 0.16em;
+	}
+
+	@media (max-width: 860px) {
+		.admin-nav {
+			position: sticky;
+			width: calc(100vw - 1rem);
+			margin-top: 0.5rem;
+		}
+
+		.desktop-menu {
+			display: none;
+		}
+
+		.hamburger {
+			display: inline-flex;
+		}
 	}
 </style>

--- a/workout-app/src/routes/+layout.svelte
+++ b/workout-app/src/routes/+layout.svelte
@@ -1,90 +1,98 @@
 <script>
-        import '../app.css';
-        import { onDestroy, onMount } from 'svelte';
-        import { auth, db } from '$lib/firebase';
-        import { onAuthStateChanged } from 'firebase/auth';
-        import { doc, getDoc } from 'firebase/firestore';
-        import { goto } from '$app/navigation';
-        import { resolve } from '$app/paths';
-        import { page } from '$app/stores';
-        import AdminNav from '$lib/components/AdminNav.svelte';
-        import { isAdmin, loading, resetAuthState, user } from '$lib/store';
+	import '../app.css';
+	import { onDestroy, onMount } from 'svelte';
+	import { auth, db } from '$lib/firebase';
+	import { onAuthStateChanged } from 'firebase/auth';
+	import { doc, getDoc } from 'firebase/firestore';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/stores';
+	import AdminNav from '$lib/components/AdminNav.svelte';
+	import { isAdmin, loading, resetAuthState, user } from '$lib/store';
 
-        let currentPath = '/';
-        const stopWatchingPage = page.subscribe(($page) => {
-                currentPath = $page.url.pathname;
-        });
+	let currentPath = '/';
+	const stopWatchingPage = page.subscribe(($page) => {
+		currentPath = $page.url.pathname;
+	});
 
-        onDestroy(() => {
-                stopWatchingPage();
-        });
+	onDestroy(() => {
+		stopWatchingPage();
+	});
 
-        onMount(() => {
-                loading.set(true);
+	onMount(() => {
+		loading.set(true);
 
-                let active = true;
-                const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
-                        if (!active) return;
+		let active = true;
+		const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+			if (!active) return;
 
-                        if (firebaseUser) {
-                                user.set({
-                                        email: firebaseUser.email ?? null,
-                                        uid: firebaseUser.uid
-                                });
+			if (firebaseUser) {
+				user.set({
+					email: firebaseUser.email ?? null,
+					uid: firebaseUser.uid
+				});
 
-                                let admin = false;
-                                let hasProfile = false;
+				let admin = false;
+				let hasProfile = false;
 
-                                try {
-                                        const profileRef = doc(db, 'profiles', firebaseUser.uid);
-                                        const profileSnap = await getDoc(profileRef);
+				try {
+					const profileRef = doc(db, 'profiles', firebaseUser.uid);
+					const profileSnap = await getDoc(profileRef);
 
-                                        if (profileSnap.exists()) {
-                                                const profile = profileSnap.data();
-                                                admin = profile.isAdmin === true;
-                                                hasProfile = true;
-                                        }
-                                } catch (error) {
-                                        console.error('Failed to load profile metadata', error);
-                                }
+					if (profileSnap.exists()) {
+						const profile = profileSnap.data();
+						admin = profile.isAdmin === true;
+						hasProfile = true;
+					}
+				} catch (error) {
+					console.error('Failed to load profile metadata', error);
+				}
 
-                                isAdmin.set(admin);
+				isAdmin.set(admin);
 
-                                if (!hasProfile && currentPath !== '/account/setup') {
-                                        goto(resolve('/account/setup'));
-                                }
+				if (!hasProfile && currentPath !== '/account/setup') {
+					goto(resolve('/account/setup'));
+				}
 
-                                loading.set(false);
-                                return;
-                        }
+				loading.set(false);
+				return;
+			}
 
-                        resetAuthState();
+			resetAuthState();
 
-                        if (currentPath.startsWith('/admin') || currentPath.startsWith('/dashboard')) {
-                                goto(resolve('/'));
-                        }
-                });
+			if (currentPath.startsWith('/admin') || currentPath.startsWith('/dashboard')) {
+				goto(resolve('/'));
+			}
+		});
 
-                return () => {
-                        active = false;
-                        unsubscribe();
-                };
-        });
+		return () => {
+			active = false;
+			unsubscribe();
+		};
+	});
 </script>
 
 <svelte:head>
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
-	<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+	<link
+		href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;700&display=swap"
+		rel="stylesheet"
+	/>
 </svelte:head>
 
 {#if $isAdmin}
-        <AdminNav />
+	<AdminNav />
 {/if}
 
 <div class="app-container">
 	{#if $loading}
-		<p>Loading...</p>
+		<div class="loading-shell" role="status" aria-live="polite">
+			<div class="loading-card">
+				<span class="loading-pulse" aria-hidden="true"></span>
+				<p>Loading your training space...</p>
+			</div>
+		</div>
 	{:else}
 		<slot />
 	{/if}

--- a/workout-app/src/routes/+page.svelte
+++ b/workout-app/src/routes/+page.svelte
@@ -6,27 +6,27 @@
 		signInWithEmailAndPassword,
 		signOut
 	} from 'firebase/auth';
-        import { user } from '$lib/store';
-        import { page } from '$app/stores';
+	import { user } from '$lib/store';
+	import { page } from '$app/stores';
 
 	let email = '';
 	let password = '';
 	let errorMessage = '';
-        let isNewUser = false;
-        let initializedFromQuery = false;
-        let redirectUrl = '/dashboard';
+	let isNewUser = false;
+	let initializedFromQuery = false;
+	let redirectUrl = '/dashboard';
 
-        $: if (!initializedFromQuery) {
-                const signupParam = $page.url.searchParams.get('signup');
-                const redirectParam = $page.url.searchParams.get('redirect');
-                if (redirectParam) {
-                        redirectUrl = redirectParam;
-                }
-                if (signupParam === '1') {
-                        isNewUser = true;
-                }
-                initializedFromQuery = true;
-        }
+	$: if (!initializedFromQuery) {
+		const signupParam = $page.url.searchParams.get('signup');
+		const redirectParam = $page.url.searchParams.get('redirect');
+		if (redirectParam) {
+			redirectUrl = redirectParam;
+		}
+		if (signupParam === '1') {
+			isNewUser = true;
+		}
+		initializedFromQuery = true;
+	}
 
 	async function handleSubmit() {
 		if (!email || !password) {
@@ -50,13 +50,13 @@
 	}
 
 	const dashboardUrl = resolve(/** @type {any} */ ('/dashboard'));
-    import { goto } from '$app/navigation';
-$: if ($user && redirectUrl) {
-    // Only redirect automatically if we came from a join link
-    if (redirectUrl !== '/dashboard') {
-        goto(resolve(redirectUrl));
-    }
-}
+	import { goto } from '$app/navigation';
+	$: if ($user && redirectUrl) {
+		// Only redirect automatically if we came from a join link
+		if (redirectUrl !== '/dashboard') {
+			goto(resolve(/** @type {any} */ (redirectUrl)));
+		}
+	}
 </script>
 
 <main class="auth-page">

--- a/workout-app/src/routes/dashboard/+page.svelte
+++ b/workout-app/src/routes/dashboard/+page.svelte
@@ -1,429 +1,761 @@
 <script>
-        // @ts-nocheck
-        import { get } from 'svelte/store';
-        import { db } from '$lib/firebase';
-        import {
-                collection,
-                query,
-                where,
-                getDocs,
-                orderBy,
-                limit,
-                doc,
-                updateDoc,
-                arrayUnion,
-                arrayRemove,
-                getDoc
-        } from 'firebase/firestore';
-        import { loading, user } from '$lib/store';
+	// @ts-nocheck
+	import { get } from 'svelte/store';
+	import { resolve } from '$app/paths';
+	import { db } from '$lib/firebase';
+	import {
+		collection,
+		query,
+		where,
+		getDocs,
+		orderBy,
+		limit,
+		doc,
+		updateDoc,
+		arrayUnion,
+		arrayRemove,
+		getDoc
+	} from 'firebase/firestore';
+	import { isAdmin, loading, user } from '$lib/store';
 
-let stats = { sessionsAttended: 0, personalBests: [] };
-let upcomingSession = null;
-let userProfile = null;
-let hasBooked = false;
-let isBooking = false;
-let isLoading = true;
-let loadError = '';
+	let stats = { sessionsAttended: 0, personalBests: [] };
+	let upcomingSession = null;
+	let userProfile = null;
+	let hasBooked = false;
+	let isBooking = false;
+	let isLoading = true;
+	let loadError = '';
 
-let lastLoadedUid = null;
-let fetchToken = 0;
+	let lastLoadedUid = null;
+	let fetchToken = 0;
 
-        function normaliseDate(value) {
-                if (!value) return null;
-                if (value instanceof Date) return value;
-                if (typeof value === 'number') return new Date(value);
-                if (typeof value === 'string') {
-                        const parsed = new Date(value);
-                        return Number.isNaN(parsed.getTime()) ? null : parsed;
-                }
-                if (typeof value.toDate === 'function') {
-                        return value.toDate();
-                }
-                if (typeof value.seconds === 'number') {
-                        return new Date(value.seconds * 1000);
-                }
-                return null;
-        }
+	function normaliseDate(value) {
+		if (!value) return null;
+		if (value instanceof Date) return value;
+		if (typeof value === 'number') return new Date(value);
+		if (typeof value === 'string') {
+			const parsed = new Date(value);
+			return Number.isNaN(parsed.getTime()) ? null : parsed;
+		}
+		if (typeof value.toDate === 'function') {
+			return value.toDate();
+		}
+		if (typeof value.seconds === 'number') {
+			return new Date(value.seconds * 1000);
+		}
+		return null;
+	}
 
-        async function loadDashboard(uid) {
-                const currentToken = ++fetchToken;
-                isLoading = true;
-                loadError = '';
+	async function loadDashboard(uid) {
+		const currentToken = ++fetchToken;
+		isLoading = true;
+		loadError = '';
 
-                const startOfToday = new Date();
-                startOfToday.setHours(0, 0, 0, 0);
+		const startOfToday = new Date();
+		startOfToday.setHours(0, 0, 0, 0);
 
-                try {
-                        const attendanceQuery = getDocs(query(collection(db, 'attendance'), where('userId', '==', uid)));
-                        const scoresQuery = getDocs(
-                                query(collection(db, 'scores'), where('userId', '==', uid), orderBy('date', 'desc'))
-                        );
-                        const sessionsQuery = getDocs(
-                                query(
-                                        collection(db, 'sessions'),
-                                        where('sessionDate', '>=', startOfToday),
-                                        orderBy('sessionDate', 'asc'),
-                                        limit(1)
-                                )
-                        );
-                        const profileQuery = getDoc(doc(db, 'profiles', uid));
+		try {
+			const attendanceQuery = getDocs(
+				query(collection(db, 'attendance'), where('userId', '==', uid))
+			);
+			const scoresQuery = getDocs(
+				query(collection(db, 'scores'), where('userId', '==', uid), orderBy('date', 'desc'))
+			);
+			const sessionsQuery = getDocs(
+				query(
+					collection(db, 'sessions'),
+					where('sessionDate', '>=', startOfToday),
+					orderBy('sessionDate', 'asc'),
+					limit(1)
+				)
+			);
+			const profileQuery = getDoc(doc(db, 'profiles', uid));
 
-                        const [attendanceSnapshot, scoresSnapshot, sessionsSnapshot, profileSnap] = await Promise.all([
-                                attendanceQuery,
-                                scoresQuery,
-                                sessionsQuery,
-                                profileQuery
-                        ]);
+			const [attendanceSnapshot, scoresSnapshot, sessionsSnapshot, profileSnap] = await Promise.all(
+				[attendanceQuery, scoresQuery, sessionsQuery, profileQuery]
+			);
 
-                        if (currentToken !== fetchToken) {
-                                return;
-                        }
+			if (currentToken !== fetchToken) {
+				return;
+			}
 
-                        stats.sessionsAttended = attendanceSnapshot.size;
-                        const scores = scoresSnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
-                        const personalBests = new Map();
-                        for (const score of scores) {
-                                const existingBest = personalBests.get(score.workoutId);
-                                if (!existingBest || Number(score.score) > Number(existingBest.score)) {
-                                        personalBests.set(score.workoutId, score);
-                                }
-                        }
-                        stats.personalBests = Array.from(personalBests.values());
+			stats.sessionsAttended = attendanceSnapshot.size;
+			const scores = scoresSnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+			const personalBests = new Map();
+			for (const score of scores) {
+				const existingBest = personalBests.get(score.workoutId);
+				if (!existingBest || Number(score.score) > Number(existingBest.score)) {
+					personalBests.set(score.workoutId, score);
+				}
+			}
+			stats.personalBests = Array.from(personalBests.values());
 
-                        userProfile = profileSnap.exists() ? profileSnap.data() : null;
+			userProfile = profileSnap.exists() ? profileSnap.data() : null;
 
-                        if (!sessionsSnapshot.empty) {
-                                const sessionDoc = sessionsSnapshot.docs[0];
-                                const sessionData = sessionDoc.data();
-                                const sessionDate = normaliseDate(sessionData.sessionDate);
+			if (!sessionsSnapshot.empty) {
+				const sessionDoc = sessionsSnapshot.docs[0];
+				const sessionData = sessionDoc.data();
+				const sessionDate = normaliseDate(sessionData.sessionDate);
 
-                                if (sessionDate) {
-                                        upcomingSession = {
-                                                id: sessionDoc.id,
-                                                ...sessionData,
-                                                sessionDate
-                                        };
-                                        hasBooked = Boolean(upcomingSession.rsvps?.some((rsvp) => rsvp.userId === uid));
-                                } else {
-                                        upcomingSession = null;
-                                        hasBooked = false;
-                                }
-                        } else {
-                                upcomingSession = null;
-                                hasBooked = false;
-                        }
-                } catch (error) {
-                        console.error('Failed to load dashboard data', error);
-                        if (currentToken === fetchToken) {
-                                loadError = 'We could not load your dashboard data. Please refresh or try again later.';
-                                stats = { sessionsAttended: 0, personalBests: [] };
-                                upcomingSession = null;
-                                userProfile = null;
-                                hasBooked = false;
-                        }
-                } finally {
-                        if (currentToken === fetchToken) {
-                                isLoading = false;
-                        }
-                }
-        }
+				if (sessionDate) {
+					upcomingSession = {
+						id: sessionDoc.id,
+						...sessionData,
+						sessionDate
+					};
+					hasBooked = Boolean(upcomingSession.rsvps?.some((rsvp) => rsvp.userId === uid));
+				} else {
+					upcomingSession = null;
+					hasBooked = false;
+				}
+			} else {
+				upcomingSession = null;
+				hasBooked = false;
+			}
+		} catch (error) {
+			console.error('Failed to load dashboard data', error);
+			if (currentToken === fetchToken) {
+				loadError = 'We could not load your dashboard data. Please refresh or try again later.';
+				stats = { sessionsAttended: 0, personalBests: [] };
+				upcomingSession = null;
+				userProfile = null;
+				hasBooked = false;
+			}
+		} finally {
+			if (currentToken === fetchToken) {
+				isLoading = false;
+			}
+		}
+	}
 
-        $: {
-                const uid = $user?.uid ?? null;
+	$: {
+		const uid = $user?.uid ?? null;
 
-                if (!uid) {
-                        lastLoadedUid = null;
-                        hasBooked = false;
-                        upcomingSession = null;
-                        userProfile = null;
-                        stats = { sessionsAttended: 0, personalBests: [] };
-                        isLoading = get(loading);
-                        loadError = '';
-                } else if (uid !== lastLoadedUid) {
-                        lastLoadedUid = uid;
-                        void loadDashboard(uid);
-                }
-        }
+		if (!uid) {
+			lastLoadedUid = null;
+			hasBooked = false;
+			upcomingSession = null;
+			userProfile = null;
+			stats = { sessionsAttended: 0, personalBests: [] };
+			isLoading = get(loading);
+			loadError = '';
+		} else if (uid !== lastLoadedUid) {
+			lastLoadedUid = uid;
+			void loadDashboard(uid);
+		}
+	}
 
-        $: isSessionToday = (() => {
-                if (!upcomingSession?.sessionDate) return false;
-                const today = new Date();
-                return (
-                        upcomingSession.sessionDate.getFullYear() === today.getFullYear() &&
-                        upcomingSession.sessionDate.getMonth() === today.getMonth() &&
-                        upcomingSession.sessionDate.getDate() === today.getDate()
-                );
-        })();
+	$: isSessionToday = (() => {
+		if (!upcomingSession?.sessionDate) return false;
+		const today = new Date();
+		return (
+			upcomingSession.sessionDate.getFullYear() === today.getFullYear() &&
+			upcomingSession.sessionDate.getMonth() === today.getMonth() &&
+			upcomingSession.sessionDate.getDate() === today.getDate()
+		);
+	})();
 
-        async function bookSpot() {
-                if (!upcomingSession || !userProfile || isBooking) return;
+	$: attendanceTotal = stats.sessionsAttended;
+	$: benchmarkTotal = stats.personalBests.length;
+	$: nextSessionCount = upcomingSession?.rsvps?.length ?? 0;
+	$: nextSessionDateLabel = upcomingSession?.sessionDate
+		? upcomingSession.sessionDate.toLocaleDateString('en-GB', {
+				weekday: 'long',
+				month: 'long',
+				day: 'numeric'
+			})
+		: '';
+	$: nextSessionTimeLabel = upcomingSession?.sessionDate
+		? upcomingSession.sessionDate.toLocaleTimeString('en-GB', {
+				hour: '2-digit',
+				minute: '2-digit'
+			})
+		: '';
+	$: coachChecklist = [
+		{
+			label: 'Create or confirm the next session',
+			done: Boolean(upcomingSession)
+		},
+		{
+			label: 'Check attendance before class starts',
+			done: Boolean(upcomingSession && nextSessionCount > 0)
+		},
+		{
+			label: 'Review member PBs for shout-outs',
+			done: benchmarkTotal > 0
+		}
+	];
 
-                const currentUser = get(user);
-                if (!currentUser?.uid) return;
+	async function bookSpot() {
+		if (!upcomingSession || !userProfile || isBooking) return;
 
-                isBooking = true;
-                try {
-                        const sessionRef = doc(db, 'sessions', upcomingSession.id);
-                        await updateDoc(sessionRef, {
-                                rsvps: arrayUnion({
-                                        userId: currentUser.uid,
-                                        displayName: userProfile.displayName
-                                })
-                        });
-                        hasBooked = true;
-                } catch (error) {
-                        console.error('Error booking spot:', error);
-                        alert('Could not book your spot. Please try again.');
-                } finally {
-                        isBooking = false;
-                }
-        }
+		const currentUser = get(user);
+		if (!currentUser?.uid) return;
 
-        async function cancelBooking() {
-                if (!upcomingSession || !userProfile || isBooking) return;
+		isBooking = true;
+		try {
+			const sessionRef = doc(db, 'sessions', upcomingSession.id);
+			await updateDoc(sessionRef, {
+				rsvps: arrayUnion({
+					userId: currentUser.uid,
+					displayName: userProfile.displayName
+				})
+			});
+			hasBooked = true;
+		} catch (error) {
+			console.error('Error booking spot:', error);
+			alert('Could not book your spot. Please try again.');
+		} finally {
+			isBooking = false;
+		}
+	}
 
-                const currentUser = get(user);
-                if (!currentUser?.uid) return;
+	async function cancelBooking() {
+		if (!upcomingSession || !userProfile || isBooking) return;
 
-                isBooking = true;
-                try {
-                        const sessionRef = doc(db, 'sessions', upcomingSession.id);
-                        await updateDoc(sessionRef, {
-                                rsvps: arrayRemove({
-                                        userId: currentUser.uid,
-                                        displayName: userProfile.displayName
-                                })
-                        });
-                        hasBooked = false;
-                } catch (error) {
-                        console.error('Error cancelling booking:', error);
-                        alert('Could not cancel your booking. Please try again.');
-                } finally {
-                        isBooking = false;
-                }
-        }
+		const currentUser = get(user);
+		if (!currentUser?.uid) return;
 
+		isBooking = true;
+		try {
+			const sessionRef = doc(db, 'sessions', upcomingSession.id);
+			await updateDoc(sessionRef, {
+				rsvps: arrayRemove({
+					userId: currentUser.uid,
+					displayName: userProfile.displayName
+				})
+			});
+			hasBooked = false;
+		} catch (error) {
+			console.error('Error cancelling booking:', error);
+			alert('Could not cancel your booking. Please try again.');
+		} finally {
+			isBooking = false;
+		}
+	}
 </script>
 
 <div class="page-container">
-<header class="dashboard-header">
-<h1>Welcome, {userProfile?.displayName || 'Member'}!</h1>
-<p>Here's a look at your progress and the next session.</p>
-</header>
+	<header class="dashboard-hero">
+		<div>
+			<p class="eyebrow">Training hub</p>
+			<h1>Welcome, {userProfile?.displayName || 'Member'}.</h1>
+			<p class="hero-copy">
+				Your next class, recent benchmarks and coach actions are now in one cleaner place.
+			</p>
+		</div>
+		{#if $isAdmin}
+			<div class="hero-actions" aria-label="Coach shortcuts">
+				<a href={resolve('/admin/create')} class="quick-action primary">Create workout</a>
+				<a href={resolve('/admin/sessions')} class="quick-action">Schedule class</a>
+			</div>
+		{/if}
+	</header>
 
-{#if isLoading}
-<p>Loading your dashboard...</p>
-{:else if loadError}
-<p class="error-state">{loadError}</p>
-{:else}
-<div class="dashboard-grid">
-<div class="main-col">
-<section class="dashboard-section">
-<h2>Upcoming Session</h2>
-{#if upcomingSession}
-<div class="session-card" class:today={isSessionToday}>
-<div class="session-info">
-<span class="session-date">
-        {upcomingSession.sessionDate.toLocaleDateString('en-GB', {
-                weekday: 'long',
-                month: 'long',
-                day: 'numeric'
-        })}
-</span>
-<h3 class="session-title">{upcomingSession.workoutTitle}</h3>
-</div>
-<div class="session-action">
-{#if isSessionToday}
-<a href={`/live/${upcomingSession.id}`} class="live-btn">I'm Here & Ready to Go!</a>
-{:else if hasBooked}
-<button class="secondary-btn" on:click={cancelBooking} disabled={isBooking}>{isBooking ? '...' : 'Cancel Booking'}</button>
-{:else}
-<button class="primary-btn" on:click={bookSpot} disabled={isBooking}>{isBooking ? '...' : 'Book My Spot'}</button>
-{/if}
-</div>
-</div>
-{:else}
-<p class="empty-state">No upcoming sessions are scheduled yet.</p>
-{/if}
-</section>
+	{#if isLoading}
+		<section class="dashboard-section loading-panel" aria-live="polite">
+			<span class="mini-loader" aria-hidden="true"></span>
+			<p>Loading your dashboard...</p>
+		</section>
+	{:else if loadError}
+		<p class="error-state">{loadError}</p>
+	{:else}
+		<section class="metric-strip" aria-label="Dashboard overview">
+			<div class="metric-card">
+				<span class="metric-label">Sessions attended</span>
+				<strong>{attendanceTotal}</strong>
+				<span>Keep stacking consistency.</span>
+			</div>
+			<div class="metric-card">
+				<span class="metric-label">Benchmarks logged</span>
+				<strong>{benchmarkTotal}</strong>
+				<span>{benchmarkTotal ? 'Tap a PB for detail.' : 'Log your first score.'}</span>
+			</div>
+			<div class="metric-card accent">
+				<span class="metric-label">Next class bookings</span>
+				<strong>{nextSessionCount}</strong>
+				<span>{upcomingSession ? upcomingSession.workoutTitle : 'No class scheduled'}</span>
+			</div>
+		</section>
 
-<section class="dashboard-section">
-<h2>Personal Bests</h2>
-{#if stats.personalBests.length === 0}
-<p class="empty-state">Complete a benchmark workout to see your results here!</p>
-{:else}
-            <div class="pb-grid">
-                    {#each stats.personalBests as pb (pb.id ?? pb.workoutId ?? pb.workoutTitle)}
-                            <a
-                                    class="pb-card"
-                                    href={`/dashboard/personal-bests/${pb.id}`}
-                                    aria-label={`View personal best details for ${pb.workoutTitle}`}
-                            >
-                                    <span class="pb-workout-title">{pb.workoutTitle}</span>
-                                    <span class="pb-score">{pb.score}</span>
-                                    <span class="pb-date">{normaliseDate(pb.date)?.toLocaleDateString() ?? ''}</span>
-                            </a>
-                    {/each}
-            </div>
-{/if}
-</section>
-</div>
-<div class="sidebar-col">
-<section class="dashboard-section">
-<h2>At a Glance</h2>
-<div class="stats-grid">
-<div class="stat-card">
-<span class="stat-value">{stats.sessionsAttended}</span>
-<span class="stat-label">Sessions Attended</span>
-</div>
-<div class="stat-card">
-<span class="stat-value">{stats.personalBests.length}</span>
-<span class="stat-label">Benchmarks Logged</span>
-</div>
-</div>
-</section>
-</div>
-</div>
-{/if}
+		<div class="dashboard-grid">
+			<div class="main-col">
+				<section class="dashboard-section session-section">
+					<div class="section-heading">
+						<div>
+							<p class="eyebrow">Next up</p>
+							<h2>Upcoming Session</h2>
+						</div>
+						{#if upcomingSession && isSessionToday}
+							<span class="today-badge">Today</span>
+						{/if}
+					</div>
+					{#if upcomingSession}
+						<div class="session-card" class:today={isSessionToday}>
+							<div class="session-info">
+								<span class="session-date">{nextSessionDateLabel}</span>
+								<h3 class="session-title">{upcomingSession.workoutTitle}</h3>
+								<div class="session-meta">
+									<span>{nextSessionTimeLabel || 'Time TBC'}</span>
+									<span>{nextSessionCount} booked</span>
+									<span
+										>{isSessionToday
+											? 'Ready for check-in'
+											: hasBooked
+												? 'You are booked'
+												: 'Book when ready'}</span
+									>
+								</div>
+							</div>
+							<div class="session-action">
+								{#if isSessionToday}
+									<a
+										href={resolve(/** @type {any} */ (`/live/${upcomingSession.id}`))}
+										class="live-btn">I'm here & ready</a
+									>
+								{:else if hasBooked}
+									<button class="secondary-btn" on:click={cancelBooking} disabled={isBooking}>
+										{isBooking ? 'Updating...' : 'Cancel booking'}
+									</button>
+								{:else}
+									<button class="primary-btn" on:click={bookSpot} disabled={isBooking}>
+										{isBooking ? 'Booking...' : 'Book my spot'}
+									</button>
+								{/if}
+							</div>
+						</div>
+					{:else}
+						<div class="empty-state rich">
+							<strong>No upcoming sessions yet.</strong>
+							<span
+								>{$isAdmin
+									? 'Schedule the next class so members can book in.'
+									: 'Your coach has not scheduled the next session yet.'}</span
+							>
+							{#if $isAdmin}
+								<a href={resolve('/admin/sessions')} class="inline-link">Create a session</a>
+							{/if}
+						</div>
+					{/if}
+				</section>
+
+				<section class="dashboard-section">
+					<div class="section-heading">
+						<div>
+							<p class="eyebrow">Progress</p>
+							<h2>Personal Bests</h2>
+						</div>
+					</div>
+					{#if stats.personalBests.length === 0}
+						<div class="empty-state rich">
+							<strong>No benchmarks yet.</strong>
+							<span>Complete a benchmark workout and your best score will appear here.</span>
+						</div>
+					{:else}
+						<div class="pb-grid">
+							{#each stats.personalBests as pb (pb.id ?? pb.workoutId ?? pb.workoutTitle)}
+								<a
+									class="pb-card"
+									href={resolve(/** @type {any} */ (`/dashboard/personal-bests/${pb.id}`))}
+									aria-label={`View personal best details for ${pb.workoutTitle}`}
+								>
+									<span class="pb-workout-title">{pb.workoutTitle}</span>
+									<span class="pb-score">{pb.score}</span>
+									<span class="pb-date"
+										>{normaliseDate(pb.date)?.toLocaleDateString() ?? 'Date not set'}</span
+									>
+								</a>
+							{/each}
+						</div>
+					{/if}
+				</section>
+			</div>
+
+			<aside class="sidebar-col">
+				{#if $isAdmin}
+					<section class="dashboard-section coach-panel">
+						<p class="eyebrow">Coach QOL</p>
+						<h2>Class checklist</h2>
+						<ul class="checklist">
+							{#each coachChecklist as item (item.label)}
+								<li class:done={item.done}>
+									<span>{item.done ? '✓' : '•'}</span>
+									{item.label}
+								</li>
+							{/each}
+						</ul>
+						<div class="coach-links">
+							<a href={resolve('/admin/attendance')}>Open check-in</a>
+							<a href={resolve('/admin/workouts')}>Workout library</a>
+							{#if upcomingSession}
+								<a href={resolve(/** @type {any} */ (`/admin/results/${upcomingSession.id}`))}
+									>Session results</a
+								>
+							{/if}
+						</div>
+					</section>
+				{/if}
+
+				<section class="dashboard-section tip-panel">
+					<p class="eyebrow">Today’s focus</p>
+					<h2>{upcomingSession ? 'Arrive prepared' : 'Build momentum'}</h2>
+					<p>
+						{upcomingSession
+							? 'Hydrate, check the workout notes and arrive five minutes early so the warm-up starts smoothly.'
+							: 'A benchmark score gives you and your coach a better baseline for future programming.'}
+					</p>
+				</section>
+			</aside>
+		</div>
+	{/if}
 </div>
 
 <style>
-/* NEW Professional Dashboard Styles */
-.page-container {
-        width: min(1400px, 100%);
-        margin: 0 auto;
-        padding: clamp(1rem, 4vw, 2rem);
-}
-.dashboard-header h1 {
-        font-family: var(--font-display);
-        color: var(--brand-yellow);
-        font-size: 3rem;
-        margin: 0;
-}
-.dashboard-header p {
-        font-size: 1.1rem;
-        color: var(--text-secondary);
-        margin-top: 0.5rem;
-}
-.dashboard-grid {
-        display: grid;
-        grid-template-columns: 2fr 1fr;
-        gap: 2rem;
-        margin-top: 2rem;
-}
-.main-col,
-.sidebar-col {
-        display: flex;
-        flex-direction: column;
-        gap: 2rem;
-}
-.dashboard-section h2 {
-        font-family: var(--font-display);
-        font-size: 1.75rem;
-        letter-spacing: 1px;
-        margin-bottom: 1rem;
-        padding-bottom: 0.5rem;
-        border-bottom: 1px solid var(--border-color);
-}
-.session-card {
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 16px;
-        padding: 1.5rem;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 1rem;
-}
-.session-card.today { border-color: var(--brand-green); box-shadow: 0 0 20px rgba(22, 163, 74, 0.2); }
-.session-title { font-size: 1.5rem; font-weight: 600; margin: 0.25rem 0; }
-.primary-btn, .secondary-btn, .live-btn { text-decoration: none; text-align: center; border: none; padding: 0.8rem 2rem; border-radius: 999px; font-weight: 700; cursor: pointer; }
-.live-btn { background: var(--brand-yellow); color: var(--deep-space); }
-.stat-card { background: var(--surface-1); border: 1px solid var(--border-color); border-radius: 16px; padding: 1.5rem; }
-.stat-value { font-family: var(--font-display); font-size: 3rem; color: var(--brand-yellow); }
-.stat-label { font-size: 0.9rem; color: var(--text-muted); }
-.stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; }
-.pb-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-.pb-card {
-        display: block;
-        background: var(--surface-2);
-        border-radius: 12px;
-        padding: 1rem;
-        text-decoration: none;
-        color: inherit;
-        border: 1px solid transparent;
-        transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-.pb-card:hover,
-.pb-card:focus-visible {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
-        border-color: var(--brand-yellow);
-}
-.pb-card:focus-visible {
-        outline: 2px solid var(--brand-yellow);
-        outline-offset: 2px;
-}
-.pb-workout-title { font-weight: 600; }
-.pb-score { font-family: var(--font-display); font-size: 2rem; color: var(--brand-yellow); }
-.pb-date { font-size: 0.8rem; color: var(--text-muted); }
-@media (max-width: 640px) {
-        .page-container {
-                padding: 1.25rem;
-        }
+	.page-container {
+		width: min(1180px, 100%);
+		margin: 0 auto;
+		padding: clamp(0.25rem, 2vw, 1rem) 0 2rem;
+	}
 
-        .dashboard-header h1 {
-                font-size: 2.25rem;
-        }
+	.dashboard-hero,
+	.dashboard-section,
+	.metric-card {
+		border: 1px solid var(--border-color);
+		background: rgba(15, 23, 42, 0.68);
+		box-shadow: var(--shadow-card);
+		backdrop-filter: blur(18px);
+	}
 
-        .dashboard-header p {
-                font-size: 1rem;
-        }
+	.dashboard-hero {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: clamp(1.4rem, 4vw, 2.4rem);
+		border-radius: var(--radius-xl);
+	}
 
-        .dashboard-grid {
-                gap: 1.25rem;
-        }
+	.eyebrow {
+		margin-bottom: 0.45rem;
+		color: var(--brand-yellow);
+		font-size: 0.76rem;
+		font-weight: 900;
+		text-transform: uppercase;
+		letter-spacing: 0.16em;
+	}
 
-        .session-card {
-                flex-direction: column;
-                align-items: stretch;
-        }
+	.dashboard-hero h1,
+	.dashboard-section h2 {
+		font-family: var(--font-display);
+		letter-spacing: 0.04em;
+		line-height: 0.95;
+	}
 
-        .session-action,
-        .session-action .primary-btn,
-        .session-action .secondary-btn,
-        .session-action .live-btn {
-                width: 100%;
-                display: block;
-        }
+	.dashboard-hero h1 {
+		max-width: 760px;
+		font-size: clamp(3rem, 8vw, 6rem);
+	}
 
-        .amrap-count {
-                width: 100%;
-                align-items: center;
-                text-align: center;
-        }
+	.hero-copy {
+		max-width: 680px;
+		margin-top: 0.9rem;
+		color: var(--text-secondary);
+		font-size: clamp(1rem, 2vw, 1.15rem);
+	}
 
-        .round-grid {
-                grid-template-columns: repeat(auto-fit, minmax(2.75rem, 1fr));
-        }
+	.hero-actions,
+	.session-meta,
+	.coach-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.7rem;
+	}
 
-        .amrap-footer {
-                flex-direction: column;
-                align-items: flex-start;
-        }
+	.quick-action,
+	.live-btn,
+	.inline-link,
+	.coach-links a {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 999px;
+		padding: 0.75rem 1rem;
+		font-weight: 900;
+		text-decoration: none;
+	}
 
-        .round-count-select,
-        .ghost-btn,
-        .pb-grid,
-        .stats-grid {
-                width: 100%;
-        }
+	.quick-action,
+	.coach-links a {
+		border: 1px solid var(--border-color);
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--text-secondary);
+	}
 
-        .pb-grid {
-                grid-template-columns: 1fr;
-        }
-}
-.empty-state { color: var(--text-muted); }
-.error-state { color: var(--error); margin-top: 1rem; text-align: center; }
-@media (max-width: 900px) { .dashboard-grid { grid-template-columns: 1fr; } }
+	.quick-action.primary,
+	.live-btn,
+	.inline-link {
+		border: 1px solid rgba(250, 204, 21, 0.3);
+		background: linear-gradient(135deg, var(--brand-yellow), var(--brand-green));
+		color: #07111f;
+	}
+
+	.metric-strip {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 1rem;
+		margin: 1rem 0;
+	}
+
+	.metric-card {
+		display: grid;
+		gap: 0.35rem;
+		padding: 1.25rem;
+		border-radius: var(--radius-lg);
+	}
+
+	.metric-card strong {
+		font-size: clamp(2rem, 5vw, 3.5rem);
+		line-height: 1;
+	}
+
+	.metric-card span:last-child {
+		color: var(--text-muted);
+	}
+
+	.metric-card.accent {
+		background: linear-gradient(145deg, rgba(250, 204, 21, 0.16), rgba(34, 197, 94, 0.1));
+	}
+
+	.metric-label {
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 900;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.dashboard-grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.8fr);
+		gap: 1rem;
+	}
+
+	.main-col,
+	.sidebar-col {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.dashboard-section {
+		border-radius: var(--radius-xl);
+		padding: clamp(1.2rem, 3vw, 1.6rem);
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.dashboard-section h2 {
+		font-size: clamp(2rem, 5vw, 3rem);
+	}
+
+	.today-badge,
+	.session-meta span {
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		padding: 0.4rem 0.65rem;
+		background: rgba(255, 255, 255, 0.08);
+		color: var(--text-secondary);
+		font-size: 0.82rem;
+		font-weight: 800;
+	}
+
+	.today-badge {
+		color: #07111f;
+		background: var(--brand-yellow);
+	}
+
+	.session-card {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.25rem;
+		padding: clamp(1rem, 3vw, 1.4rem);
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-lg);
+		background: rgba(255, 255, 255, 0.07);
+	}
+
+	.session-card.today {
+		border-color: rgba(250, 204, 21, 0.45);
+		box-shadow:
+			0 0 0 1px rgba(250, 204, 21, 0.12),
+			var(--shadow-card);
+	}
+
+	.session-info {
+		display: grid;
+		gap: 0.7rem;
+	}
+
+	.session-date {
+		color: var(--brand-yellow);
+		font-weight: 900;
+	}
+
+	.session-title {
+		font-size: clamp(1.5rem, 4vw, 2.4rem);
+		line-height: 1.05;
+	}
+
+	.session-action {
+		min-width: min(260px, 100%);
+	}
+
+	.pb-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 0.85rem;
+	}
+
+	.pb-card {
+		display: grid;
+		gap: 0.45rem;
+		min-height: 150px;
+		padding: 1rem;
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-lg);
+		background: rgba(255, 255, 255, 0.07);
+		text-decoration: none;
+		transition:
+			transform var(--transition),
+			border-color var(--transition),
+			background var(--transition);
+	}
+
+	.pb-card:hover {
+		transform: translateY(-3px);
+		border-color: rgba(250, 204, 21, 0.35);
+		background: rgba(255, 255, 255, 0.1);
+	}
+
+	.pb-workout-title,
+	.pb-date {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.pb-score {
+		align-self: end;
+		color: var(--text-primary);
+		font-size: 2.2rem;
+		font-weight: 900;
+	}
+
+	.empty-state.rich {
+		display: grid;
+		gap: 0.7rem;
+		padding: 1.25rem;
+		border: 1px dashed var(--border-color);
+		border-radius: var(--radius-lg);
+		color: var(--text-muted);
+		background: rgba(255, 255, 255, 0.045);
+	}
+
+	.empty-state strong {
+		color: var(--text-primary);
+	}
+
+	.inline-link {
+		width: fit-content;
+		margin-top: 0.25rem;
+	}
+
+	.checklist {
+		display: grid;
+		gap: 0.75rem;
+		margin: 1rem 0;
+		list-style: none;
+	}
+
+	.checklist li {
+		display: flex;
+		gap: 0.65rem;
+		align-items: flex-start;
+		color: var(--text-secondary);
+	}
+
+	.checklist span {
+		display: grid;
+		width: 1.45rem;
+		height: 1.45rem;
+		flex: 0 0 auto;
+		place-items: center;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.1);
+		color: var(--text-muted);
+		font-size: 0.82rem;
+		font-weight: 900;
+	}
+
+	.checklist li.done span {
+		background: var(--success);
+		color: #052e16;
+	}
+
+	.tip-panel p:last-child {
+		color: var(--text-secondary);
+	}
+
+	.loading-panel {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-top: 1rem;
+	}
+
+	.mini-loader {
+		width: 1rem;
+		height: 1rem;
+		border-radius: 999px;
+		background: var(--brand-yellow);
+		box-shadow: 0 0 24px rgba(250, 204, 21, 0.65);
+		animation: pulse 1s infinite;
+	}
+
+	.error-state {
+		margin-top: 1rem;
+		padding: 1rem;
+		border: 1px solid rgba(251, 113, 133, 0.3);
+		border-radius: var(--radius-lg);
+		color: var(--error);
+		background: rgba(251, 113, 133, 0.08);
+		text-align: center;
+	}
+
+	@media (max-width: 900px) {
+		.dashboard-hero,
+		.session-card {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.hero-actions,
+		.session-action,
+		.session-action .primary-btn,
+		.session-action .secondary-btn,
+		.session-action .live-btn {
+			width: 100%;
+		}
+
+		.metric-strip,
+		.dashboard-grid {
+			grid-template-columns: 1fr;
+		}
+	}
 </style>

--- a/workout-app/src/routes/live/[sessionId]/+page.svelte
+++ b/workout-app/src/routes/live/[sessionId]/+page.svelte
@@ -2799,35 +2799,6 @@ function formatTime(s) {
         cursor: not-allowed;
 }
 
-.selector-grid {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-}
-
-.selector-grid label {
-        border: 1px solid var(--border-color);
-        border-radius: 999px;
-        padding: 0.4rem 0.75rem;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        cursor: pointer;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-        transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.selector-grid label.active {
-        background: var(--brand-yellow);
-        border-color: var(--brand-yellow);
-        color: var(--bg-main);
-}
-
-.selector-grid label input {
-        display: none;
-}
-
 .score-card.placeholder {
         align-items: center;
         justify-content: center;
@@ -2879,24 +2850,12 @@ function formatTime(s) {
         flex-wrap: wrap;
 }
 
-.score-title {
-        display: flex;
-        flex-direction: column;
-        gap: 0.35rem;
-}
-
 .score-eyebrow {
         font-size: 0.75rem;
         font-weight: 600;
         letter-spacing: 0.08em;
         text-transform: uppercase;
         color: var(--text-muted);
-}
-
-.score-title h2 {
-        margin: 0;
-        font-size: 1.75rem;
-        color: var(--text-secondary);
 }
 
 .score-subtitle {


### PR DESCRIPTION
### Motivation
- Refresh the visual system so the app feels modern, usable and coach-focused (clear hero, metrics and better forms/buttons).  
- Improve coach quality-of-life by adding a persistent admin navigation and dashboard shortcuts to common admin flows.  
- Eliminate Svelte diagnostics and navigation issues caused by unresolved route strings and unused CSS so the app builds cleanly.

### Description
- Reworked the global design tokens and styles in `src/app.css` to introduce a deeper background, glass panels, improved form controls, button system, loading visuals and responsive adjustments.  
- Replaced the hamburger-only admin navigation with a sticky `AdminNav` component that provides desktop quick-links, a mobile menu, keyboard Escape handling and route-safe `resolve()` links (`src/lib/components/AdminNav.svelte`).  
- Rebuilt the member/coach dashboard into a compact training hub with hero, metric strip, richer upcoming-session card, PB cards, a coach checklist and tip panel (`src/routes/dashboard/+page.svelte`).  
- Added a branded loading shell to `src/routes/+layout.svelte` and improved auth page redirect typing by casting dynamic routes with `resolve(/** @type {any} */ (...))` to satisfy Svelte diagnostics (`src/routes/+page.svelte`).  
- Removed stale/unused live-session CSS selectors to silence false-positive warnings from `svelte-check` and updated a few hrefs to use `resolve()` for lint safety (`src/routes/live/[sessionId]/+page.svelte`, various route files).

### Testing
- Ran `npm run check` (Svelte diagnostics) and verified `svelte-check` reports 0 errors and 0 warnings. — Passed.  
- Built a production bundle with placeholder Firebase env vars using `VITE_API_KEY=... npm run build` and verified the Vite build completed successfully. — Passed.  
- Ran linters/formatters `npx eslint src/lib/components/AdminNav.svelte` and `npx prettier --check ...` to verify formatting and component lint rules; fixes applied where needed. — Passed.  
- Installed Playwright and host deps (`npx playwright install chromium` and `npx playwright install-deps chromium`) and captured a screenshot of the running dev server to validate the updated auth page rendering. — Passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bf2dc950832fae57c6048b4aa4dc)