### PR TITLE
Polish live timer and dashboard UI

### DIFF
--- a/workout-app/src/routes/admin/create/+page.svelte
+++ b/workout-app/src/routes/admin/create/+page.svelte
@@ -1,1688 +1,1783 @@
 <script>
-  // @ts-nocheck
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { resolve } from '$app/paths';
-  import { get } from 'svelte/store';
-  import { db } from '$lib/firebase';
-  import { collection, addDoc, serverTimestamp, getDocs, doc, setDoc } from 'firebase/firestore';
-  import { user } from '$lib/store';
-  import { DEFAULT_CHIPPER_REP_SCHEME, createDefaultChipperStep, normaliseChipperSteps, hasIncompleteChipperStep } from '$lib/chipper';
-
-  const FALLBACK_CATEGORIES = ['Bodyweight', 'Cardio Machine', 'Resistance'];
-
-  let categoryOptions = [...FALLBACK_CATEGORIES].sort((a, b) => a.localeCompare(b));
-  let defaultCategory = categoryOptions[0];
-
-  let title = '';
-  let type = 'Circuit';
-  let mode = 'Individual';
-  let previousMode = mode;
-  let isBenchmark = false;
-  let notes = '';
-
-  function getDefaultIndividualExercise() {
-    return {
-      name: '',
-      description: '',
-      category: defaultCategory,
-      equipment: [],
-      equipmentInput: ''
-    };
-  }
-
-  function getDefaultPartnerStation(index = 0) {
-    return {
-      name: `Station ${index + 1}`,
-      p1: { task: '', category: defaultCategory, equipment: [] },
-      p2: { task: '', category: defaultCategory, equipment: [] },
-      startsOn: 'P1'
-    };
-  }
-
-  function getDefaultChipperSteps() {
-    return DEFAULT_CHIPPER_REP_SCHEME.map((_, index) => createDefaultChipperStep(index, defaultCategory));
-  }
-
-  function sanitizeChipperStep(step, index = 0) {
-    const schemeIndex = Math.min(index, DEFAULT_CHIPPER_REP_SCHEME.length - 1);
-    const fallback = DEFAULT_CHIPPER_REP_SCHEME[schemeIndex] ?? 10;
-    const repsValue = Number(step?.reps);
-    return {
-      name: step?.name ?? '',
-      reps: Number.isFinite(repsValue) && repsValue > 0 ? Math.round(repsValue) : Math.round(fallback),
-      category: sanitizeCategory(step?.category)
-    };
-  }
-
-  function sanitizeFinisher(finisher = {}) {
-    const defaultDescription = 'Max calories until the clock hits zero.';
-    const rawName = typeof finisher?.name === 'string' ? finisher.name.trim() : '';
-    const rawDescription = typeof finisher?.description === 'string' ? finisher.description.trim() : '';
-    return {
-      name: rawName || 'Max Calories',
-      description: rawDescription || defaultDescription,
-      category: sanitizeCategory(finisher?.category)
-    };
-  }
-
-  function sanitizeCategory(category) {
-    return categoryOptions.includes(category) ? category : defaultCategory;
-  }
-
-  function normalizeEquipmentList(value) {
-    if (Array.isArray(value)) {
-      return value
-        .filter((item) => typeof item === 'string')
-        .map((item) => item.trim())
-        .filter(Boolean);
-    }
-
-    if (typeof value === 'string') {
-      return value
-        .split(',')
-        .map((item) => item.trim())
-        .filter(Boolean);
-    }
-
-    return [];
-  }
-
-  function sanitizeEquipmentInput(exercise = {}) {
-    const list = normalizeEquipmentList(
-      typeof exercise.equipmentInput === 'string' ? exercise.equipmentInput : exercise.equipment
-    );
-
-    return {
-      ...exercise,
-      equipment: list,
-      equipmentInput: list.join(', ')
-    };
-  }
-
-  function sanitizePartnerEquipmentInput(station = {}) {
-    const p1Equipment = normalizeEquipmentList(
-      typeof station?.p1?.equipmentInput === 'string' ? station.p1.equipmentInput : station?.p1?.equipment
-    );
-    const p2Equipment = normalizeEquipmentList(
-      typeof station?.p2?.equipmentInput === 'string' ? station.p2.equipmentInput : station?.p2?.equipment
-    );
-
-    return {
-      ...station,
-      p1: {
-        ...station.p1,
-        equipment: p1Equipment,
-        equipmentInput: p1Equipment.join(', ')
-      },
-      p2: {
-        ...station.p2,
-        equipment: p2Equipment,
-        equipmentInput: p2Equipment.join(', ')
-      }
-    };
-  }
-
-  const DEFAULT_EMOM_SETTINGS = {
-    restEvery: '',
-    restDuration: '',
-    restLabel: 'Recovery Minute'
-  };
-
-  let emomSettings = { ...DEFAULT_EMOM_SETTINGS };
-
-  function sanitizeEmomSettings(settings = {}) {
-    const every = Number(settings.restEvery);
-    const duration = Number(settings.restDuration);
-    const label = typeof settings.restLabel === 'string' ? settings.restLabel.trim() : '';
-
-    const restEvery = Number.isFinite(every) && every > 0 ? Math.round(every) : 0;
-    const restDuration = Number.isFinite(duration) && duration > 0 ? Math.round(duration) : 0;
-
-    if (!restEvery || !restDuration) {
-      return null;
-    }
-
-    return {
-      restEvery,
-      restDuration,
-      restLabel: label || 'Recovery Minute'
-    };
-  }
-
-  function normalizeStartsOn(value) {
-    return value === 'P2' ? 'P2' : 'P1';
-  }
-
-  let exercises =
-    mode === 'Partner'
-      ? [sanitizePartnerEquipmentInput(getDefaultPartnerStation())]
-      : mode === 'Chipper'
-      ? getDefaultChipperSteps()
-      : [sanitizeEquipmentInput(getDefaultIndividualExercise())];
-
-  let chipperFinisher = sanitizeFinisher({ category: 'Cardio Machine' });
-
-  let exerciseLibrary = [];
-  let allExerciseNames = [];
-  let isLibraryOpen = false;
-  let librarySearchTerm = '';
-  let librarySearchInput;
-  let selectedLibraryIds = [];
-  let isSubmitting = false;
-  let successMessage = '';
-  let errorMessage = '';
-
-  const workoutsUrl = resolve('/admin/workouts');
-
-  onMount(async () => {
-    const querySnapshot = await getDocs(collection(db, 'exercises'));
-    exerciseLibrary = querySnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
-
-    const derivedCategories = Array.from(
-      new Set(
-        exerciseLibrary
-          .map((exercise) => (typeof exercise.category === 'string' ? exercise.category.trim() : ''))
-          .filter((category) => category.length > 0)
-      )
-    ).sort((a, b) => a.localeCompare(b));
-
-    categoryOptions =
-      derivedCategories.length > 0
-        ? derivedCategories
-        : [...FALLBACK_CATEGORIES].sort((a, b) => a.localeCompare(b));
-    defaultCategory = categoryOptions[0];
-
-    if (mode === 'Partner') {
-      exercises = exercises.map((exercise) => {
-        const station = sanitizePartnerEquipmentInput(exercise);
-        return {
-          ...station,
-          p1: { ...station.p1, category: sanitizeCategory(station.p1?.category) },
-          p2: { ...station.p2, category: sanitizeCategory(station.p2?.category) }
-        };
-      });
-    } else if (mode === 'Chipper') {
-      exercises = exercises.map((step, index) => sanitizeChipperStep(step, index));
-      chipperFinisher = sanitizeFinisher(chipperFinisher);
-    } else {
-      exercises = exercises.map((exercise) => {
-        const entry = sanitizeEquipmentInput(exercise);
-        return {
-          ...entry,
-          category: sanitizeCategory(entry.category)
-        };
-      });
-    }
-  });
-
-  $: allExerciseNames = Array.from(
-    new Set([
-      ...exerciseLibrary.map((exercise) => exercise.name).filter(Boolean),
-      ...(
-        mode === 'Partner'
-          ? exercises.flatMap((exercise) => [exercise.p1?.task, exercise.p2?.task])
-          : mode === 'Chipper'
-          ? exercises.map((exercise) => exercise.name)
-          : exercises.map((exercise) => exercise.name)
-      ).filter((name) => Boolean(name)),
-      ...(mode === 'Chipper' && chipperFinisher.name ? [chipperFinisher.name] : [])
-    ])
-  ).sort((a, b) => a.localeCompare(b));
-
-  $: filteredLibrary = exerciseLibrary
-    .filter((exercise) => {
-      const name = exercise.name ?? '';
-      return name.toLowerCase().includes(librarySearchTerm.toLowerCase());
-    })
-    .sort((a, b) => {
-      const nameA = a.name ?? '';
-      const nameB = b.name ?? '';
-      return nameA.localeCompare(nameB);
-    });
-
-  $: if (
-    type !== 'EMOM' &&
-    (emomSettings.restEvery || emomSettings.restDuration || emomSettings.restLabel !== DEFAULT_EMOM_SETTINGS.restLabel)
-  ) {
-    emomSettings = { ...DEFAULT_EMOM_SETTINGS };
-  }
-
-  $: if (mode !== previousMode) {
-    if (mode === 'Partner') {
-      exercises = [sanitizePartnerEquipmentInput(getDefaultPartnerStation())];
-    } else if (mode === 'Chipper') {
-      exercises = getDefaultChipperSteps();
-      chipperFinisher = sanitizeFinisher(chipperFinisher);
-    } else {
-      exercises = [sanitizeEquipmentInput(getDefaultIndividualExercise())];
-    }
-    previousMode = mode;
-  }
-
-  function addExercise() {
-    exercises = [
-      ...exercises,
-      mode === 'Partner'
-        ? sanitizePartnerEquipmentInput(getDefaultPartnerStation(exercises.length))
-        : mode === 'Chipper'
-        ? sanitizeChipperStep(createDefaultChipperStep(exercises.length, defaultCategory), exercises.length)
-        : sanitizeEquipmentInput(getDefaultIndividualExercise())
-    ];
-  }
-
-  function removeExercise(index) {
-    exercises = exercises.filter((_, i) => i !== index);
-  }
-
-  function addExerciseFromLibrary(libraryExercise) {
-    if (!libraryExercise?.name) return;
-
-    const category = sanitizeCategory(libraryExercise.category);
-    const equipment = Array.isArray(libraryExercise.equipment) ? libraryExercise.equipment : [];
-
-    if (mode === 'Partner') {
-      for (let i = 0; i < exercises.length; i += 1) {
-        const station = exercises[i];
-        if (!station.p1.task?.trim?.()) {
-          const updatedStation = sanitizePartnerEquipmentInput({
-            ...station,
-            p1: { ...station.p1, task: libraryExercise.name, category, equipment }
-          });
-          exercises = exercises.map((ex, idx) => (idx === i ? updatedStation : ex));
-          return;
-        }
-
-        if (!station.p2.task?.trim?.()) {
-          const updatedStation = sanitizePartnerEquipmentInput({
-            ...station,
-            p2: { ...station.p2, task: libraryExercise.name, category, equipment }
-          });
-          exercises = exercises.map((ex, idx) => (idx === i ? updatedStation : ex));
-          return;
-        }
-      }
-
-      const baseStation = getDefaultPartnerStation(exercises.length);
-      const newStation = sanitizePartnerEquipmentInput({
-        ...baseStation,
-        p1: {
-          ...baseStation.p1,
-          task: libraryExercise.name,
-          category,
-          equipment
-        }
-      });
-      exercises = [...exercises, newStation];
-      return;
-    }
-
-    if (mode === 'Chipper') {
-      for (let i = 0; i < exercises.length; i += 1) {
-        const step = exercises[i];
-        if (!step.name?.trim?.()) {
-          const updatedStep = {
-            ...step,
-            name: libraryExercise.name,
-            category
-          };
-          exercises = exercises.map((ex, idx) => (idx === i ? updatedStep : ex));
-          return;
-        }
-      }
-
-      const newStep = sanitizeChipperStep(createDefaultChipperStep(exercises.length, category), exercises.length);
-      newStep.name = libraryExercise.name;
-      newStep.category = category;
-      exercises = [...exercises, newStep];
-      return;
-    }
-
-    const newExercise = sanitizeEquipmentInput({
-      ...getDefaultIndividualExercise(),
-      name: libraryExercise.name,
-      category,
-      equipment,
-      description: ''
-    });
-    exercises = [...exercises, newExercise];
-  }
-
-  function validateExercises() {
-    if (mode === 'Partner') {
-      return exercises.some((exercise) => {
-        const stationName = exercise.name?.trim?.();
-        const p1Task = exercise.p1?.task?.trim?.();
-        const p2Task = exercise.p2?.task?.trim?.();
-        return !stationName || !p1Task || !p2Task;
-      });
-    }
-
-    if (mode === 'Chipper') {
-      const hasInvalidStep = exercises.some((step) => hasIncompleteChipperStep(step));
-      const finisherName = chipperFinisher.name?.trim?.();
-      return hasInvalidStep || !finisherName;
-    }
-
-    return exercises.some((exercise) => !exercise.name?.trim?.());
-  }
-
-  $: if (isLibraryOpen && librarySearchInput) {
-    librarySearchInput.focus();
-  }
-
-  function openLibrary() {
-    librarySearchTerm = '';
-    selectedLibraryIds = [];
-    isLibraryOpen = true;
-  }
-
-  function closeLibrary() {
-    isLibraryOpen = false;
-    librarySearchTerm = '';
-    selectedLibraryIds = [];
-  }
-
-  function clearLibrarySearch() {
-    librarySearchTerm = '';
-    librarySearchInput?.focus?.();
-  }
-
-  function toggleLibrarySelection(libraryExerciseId) {
-    if (!libraryExerciseId) return;
-
-    selectedLibraryIds = selectedLibraryIds.includes(libraryExerciseId)
-      ? selectedLibraryIds.filter((id) => id !== libraryExerciseId)
-      : [...selectedLibraryIds, libraryExerciseId];
-  }
-
-  function importSelectedExercises() {
-    if (!selectedLibraryIds.length) return;
-
-    const exercisesById = new Map(exerciseLibrary.map((exercise) => [exercise.id, exercise]));
-
-    for (const exerciseId of selectedLibraryIds) {
-      const libraryExercise = exercisesById.get(exerciseId);
-
-      if (libraryExercise) {
-        addExerciseFromLibrary(libraryExercise);
-      }
-    }
-
-    closeLibrary();
-  }
-
-  function handleOverlayKeyDown(event) {
-    if (!isLibraryOpen) return;
-
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      closeLibrary();
-      return;
-    }
-
-    if (
-      event.currentTarget !== window &&
-      event.target === event.currentTarget &&
-      (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar')
-    ) {
-      event.preventDefault();
-      closeLibrary();
-    }
-  }
-
-  async function saveWorkout() {
-    const trimmedTitle = title?.trim?.() ?? '';
-
-    if (!trimmedTitle || validateExercises()) {
-      errorMessage = 'Please complete the workout title and all required exercise fields before saving.';
-      successMessage = '';
-      return;
-    }
-
-    const currentUser = get(user);
-    if (!currentUser?.uid) {
-      errorMessage = 'You need to be signed in to create workouts.';
-      successMessage = '';
-      return;
-    }
-
-    isSubmitting = true;
-    errorMessage = '';
-    successMessage = '';
-
-    try {
-    let normalizedExercises = [];
-    let chipperPayload = null;
-
-    if (mode === 'Partner') {
-      normalizedExercises = exercises.map((exercise, index) => ({
-        name: exercise.name?.trim?.() || `Station ${index + 1}`,
-        p1: {
-          task: exercise.p1?.task?.trim?.() ?? '',
-          category: sanitizeCategory(exercise.p1?.category),
-          equipment: normalizeEquipmentList(
-            typeof exercise.p1?.equipmentInput === 'string'
-              ? exercise.p1.equipmentInput
-              : exercise.p1?.equipment
-          )
-        },
-        p2: {
-          task: exercise.p2?.task?.trim?.() ?? '',
-          category: sanitizeCategory(exercise.p2?.category),
-          equipment: normalizeEquipmentList(
-            typeof exercise.p2?.equipmentInput === 'string'
-              ? exercise.p2.equipmentInput
-              : exercise.p2?.equipment
-          )
-        },
-        startsOn: normalizeStartsOn(exercise.startsOn)
-      }));
-    } else if (mode === 'Chipper') {
-      const steps = normaliseChipperSteps(exercises, sanitizeCategory);
-      const finisher = sanitizeFinisher(chipperFinisher);
-      chipperPayload = {
-        steps,
-        finisher
-      };
-
-      normalizedExercises = [
-        {
-          name: finisher.name?.trim?.() || 'Max Calories',
-          description: finisher.description?.trim?.() || 'Max calories until the clock hits zero.',
-          category: sanitizeCategory(finisher.category),
-          isFinisher: true,
-          metric: 'Calories'
-        }
-      ];
-    } else {
-      normalizedExercises = exercises.map((exercise) => {
-        const entry = sanitizeEquipmentInput(exercise);
-        return {
-          name: entry.name?.trim?.() ?? '',
-          description: entry.description?.trim?.() ?? '',
-          category: sanitizeCategory(entry.category),
-          equipment: entry.equipment
-        };
-      });
-    }
-
-    const emomPayload = type === 'EMOM' ? sanitizeEmomSettings(emomSettings) : null;
-
-    const workoutData = {
-      title: trimmedTitle,
-      type,
-      mode,
-      isBenchmark,
-      notes: notes?.trim?.() ?? '',
-      exercises: normalizedExercises,
-      chipper: chipperPayload,
-      emom: emomPayload,
-      creatorId: currentUser.uid,
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp()
-    };
-
-    await addDoc(collection(db, 'workouts'), workoutData);
-
-    const namesToPersist =
-      mode === 'Partner'
-        ? normalizedExercises.flatMap((exercise) => [exercise.p1.task, exercise.p2.task])
-        : mode === 'Chipper'
-        ? [
-            ...new Set([
-              ...chipperPayload.steps.map((step) => step.name),
-              chipperPayload.finisher?.name ?? ''
-            ])
-          ]
-        : normalizedExercises.map((exercise) => exercise.name);
-
-    for (const rawName of namesToPersist) {
-      const exerciseName = rawName?.trim?.();
-      if (!exerciseName) continue;
-
-      const exerciseRef = doc(db, 'exercises', exerciseName.toLowerCase());
-      await setDoc(exerciseRef, { name: exerciseName }, { merge: true });
-    }
-
-      successMessage = 'Workout created successfully! Redirecting...';
-      setTimeout(() => goto(workoutsUrl), 1200);
-    } catch (error) {
-      console.error('Error saving workout: ', error);
-      errorMessage = 'Failed to save workout. Please try again.';
-    } finally {
-      isSubmitting = false;
-    }
-  }
+	// @ts-nocheck
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { get } from 'svelte/store';
+	import { db } from '$lib/firebase';
+	import { collection, addDoc, serverTimestamp, getDocs, doc, setDoc } from 'firebase/firestore';
+	import { user } from '$lib/store';
+	import {
+		DEFAULT_CHIPPER_REP_SCHEME,
+		createDefaultChipperStep,
+		normaliseChipperSteps,
+		hasIncompleteChipperStep
+	} from '$lib/chipper';
+
+	const FALLBACK_CATEGORIES = ['Bodyweight', 'Cardio Machine', 'Resistance'];
+
+	let categoryOptions = [...FALLBACK_CATEGORIES].sort((a, b) => a.localeCompare(b));
+	let defaultCategory = categoryOptions[0];
+
+	let title = '';
+	let type = 'Circuit';
+	let mode = 'Individual';
+	let previousMode = mode;
+	let isBenchmark = false;
+	let notes = '';
+
+	function getDefaultIndividualExercise() {
+		return {
+			name: '',
+			description: '',
+			category: defaultCategory,
+			equipment: [],
+			equipmentInput: ''
+		};
+	}
+
+	function getDefaultPartnerStation(index = 0) {
+		return {
+			name: `Station ${index + 1}`,
+			p1: { task: '', category: defaultCategory, equipment: [] },
+			p2: { task: '', category: defaultCategory, equipment: [] },
+			startsOn: 'P1'
+		};
+	}
+
+	function getDefaultChipperSteps() {
+		return DEFAULT_CHIPPER_REP_SCHEME.map((_, index) =>
+			createDefaultChipperStep(index, defaultCategory)
+		);
+	}
+
+	function sanitizeChipperStep(step, index = 0) {
+		const schemeIndex = Math.min(index, DEFAULT_CHIPPER_REP_SCHEME.length - 1);
+		const fallback = DEFAULT_CHIPPER_REP_SCHEME[schemeIndex] ?? 10;
+		const repsValue = Number(step?.reps);
+		return {
+			name: step?.name ?? '',
+			reps:
+				Number.isFinite(repsValue) && repsValue > 0 ? Math.round(repsValue) : Math.round(fallback),
+			category: sanitizeCategory(step?.category)
+		};
+	}
+
+	function sanitizeFinisher(finisher = {}) {
+		const defaultDescription = 'Max calories until the clock hits zero.';
+		const rawName = typeof finisher?.name === 'string' ? finisher.name.trim() : '';
+		const rawDescription =
+			typeof finisher?.description === 'string' ? finisher.description.trim() : '';
+		return {
+			name: rawName || 'Max Calories',
+			description: rawDescription || defaultDescription,
+			category: sanitizeCategory(finisher?.category)
+		};
+	}
+
+	function sanitizeCategory(category) {
+		return categoryOptions.includes(category) ? category : defaultCategory;
+	}
+
+	function normalizeEquipmentList(value) {
+		if (Array.isArray(value)) {
+			return value
+				.filter((item) => typeof item === 'string')
+				.map((item) => item.trim())
+				.filter(Boolean);
+		}
+
+		if (typeof value === 'string') {
+			return value
+				.split(',')
+				.map((item) => item.trim())
+				.filter(Boolean);
+		}
+
+		return [];
+	}
+
+	function sanitizeEquipmentInput(exercise = {}) {
+		const list = normalizeEquipmentList(
+			typeof exercise.equipmentInput === 'string' ? exercise.equipmentInput : exercise.equipment
+		);
+
+		return {
+			...exercise,
+			equipment: list,
+			equipmentInput: list.join(', ')
+		};
+	}
+
+	function sanitizePartnerEquipmentInput(station = {}) {
+		const p1Equipment = normalizeEquipmentList(
+			typeof station?.p1?.equipmentInput === 'string'
+				? station.p1.equipmentInput
+				: station?.p1?.equipment
+		);
+		const p2Equipment = normalizeEquipmentList(
+			typeof station?.p2?.equipmentInput === 'string'
+				? station.p2.equipmentInput
+				: station?.p2?.equipment
+		);
+
+		return {
+			...station,
+			p1: {
+				...station.p1,
+				equipment: p1Equipment,
+				equipmentInput: p1Equipment.join(', ')
+			},
+			p2: {
+				...station.p2,
+				equipment: p2Equipment,
+				equipmentInput: p2Equipment.join(', ')
+			}
+		};
+	}
+
+	const DEFAULT_EMOM_SETTINGS = {
+		restEvery: '',
+		restDuration: '',
+		restLabel: 'Recovery Minute'
+	};
+
+	let emomSettings = { ...DEFAULT_EMOM_SETTINGS };
+
+	function sanitizeEmomSettings(settings = {}) {
+		const every = Number(settings.restEvery);
+		const duration = Number(settings.restDuration);
+		const label = typeof settings.restLabel === 'string' ? settings.restLabel.trim() : '';
+
+		const restEvery = Number.isFinite(every) && every > 0 ? Math.round(every) : 0;
+		const restDuration = Number.isFinite(duration) && duration > 0 ? Math.round(duration) : 0;
+
+		if (!restEvery || !restDuration) {
+			return null;
+		}
+
+		return {
+			restEvery,
+			restDuration,
+			restLabel: label || 'Recovery Minute'
+		};
+	}
+
+	function normalizeStartsOn(value) {
+		return value === 'P2' ? 'P2' : 'P1';
+	}
+
+	let exercises =
+		mode === 'Partner'
+			? [sanitizePartnerEquipmentInput(getDefaultPartnerStation())]
+			: mode === 'Chipper'
+				? getDefaultChipperSteps()
+				: [sanitizeEquipmentInput(getDefaultIndividualExercise())];
+
+	let chipperFinisher = sanitizeFinisher({ category: 'Cardio Machine' });
+
+	let exerciseLibrary = [];
+	let allExerciseNames = [];
+	let isLibraryOpen = false;
+	let librarySearchTerm = '';
+	let librarySearchInput;
+	let selectedLibraryIds = [];
+	let isSubmitting = false;
+	let successMessage = '';
+	let errorMessage = '';
+
+	const workoutsUrl = resolve('/admin/workouts');
+
+	onMount(async () => {
+		const querySnapshot = await getDocs(collection(db, 'exercises'));
+		exerciseLibrary = querySnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+
+		const derivedCategories = Array.from(
+			new Set(
+				exerciseLibrary
+					.map((exercise) =>
+						typeof exercise.category === 'string' ? exercise.category.trim() : ''
+					)
+					.filter((category) => category.length > 0)
+			)
+		).sort((a, b) => a.localeCompare(b));
+
+		categoryOptions =
+			derivedCategories.length > 0
+				? derivedCategories
+				: [...FALLBACK_CATEGORIES].sort((a, b) => a.localeCompare(b));
+		defaultCategory = categoryOptions[0];
+
+		if (mode === 'Partner') {
+			exercises = exercises.map((exercise) => {
+				const station = sanitizePartnerEquipmentInput(exercise);
+				return {
+					...station,
+					p1: { ...station.p1, category: sanitizeCategory(station.p1?.category) },
+					p2: { ...station.p2, category: sanitizeCategory(station.p2?.category) }
+				};
+			});
+		} else if (mode === 'Chipper') {
+			exercises = exercises.map((step, index) => sanitizeChipperStep(step, index));
+			chipperFinisher = sanitizeFinisher(chipperFinisher);
+		} else {
+			exercises = exercises.map((exercise) => {
+				const entry = sanitizeEquipmentInput(exercise);
+				return {
+					...entry,
+					category: sanitizeCategory(entry.category)
+				};
+			});
+		}
+	});
+
+	$: allExerciseNames = Array.from(
+		new Set([
+			...exerciseLibrary.map((exercise) => exercise.name).filter(Boolean),
+			...(mode === 'Partner'
+				? exercises.flatMap((exercise) => [exercise.p1?.task, exercise.p2?.task])
+				: mode === 'Chipper'
+					? exercises.map((exercise) => exercise.name)
+					: exercises.map((exercise) => exercise.name)
+			).filter((name) => Boolean(name)),
+			...(mode === 'Chipper' && chipperFinisher.name ? [chipperFinisher.name] : [])
+		])
+	).sort((a, b) => a.localeCompare(b));
+
+	$: filteredLibrary = exerciseLibrary
+		.filter((exercise) => {
+			const name = exercise.name ?? '';
+			return name.toLowerCase().includes(librarySearchTerm.toLowerCase());
+		})
+		.sort((a, b) => {
+			const nameA = a.name ?? '';
+			const nameB = b.name ?? '';
+			return nameA.localeCompare(nameB);
+		});
+
+	$: if (
+		type !== 'EMOM' &&
+		(emomSettings.restEvery ||
+			emomSettings.restDuration ||
+			emomSettings.restLabel !== DEFAULT_EMOM_SETTINGS.restLabel)
+	) {
+		emomSettings = { ...DEFAULT_EMOM_SETTINGS };
+	}
+
+	$: if (mode !== previousMode) {
+		if (mode === 'Partner') {
+			exercises = [sanitizePartnerEquipmentInput(getDefaultPartnerStation())];
+		} else if (mode === 'Chipper') {
+			exercises = getDefaultChipperSteps();
+			chipperFinisher = sanitizeFinisher(chipperFinisher);
+		} else {
+			exercises = [sanitizeEquipmentInput(getDefaultIndividualExercise())];
+		}
+		previousMode = mode;
+	}
+
+	function addExercise() {
+		exercises = [
+			...exercises,
+			mode === 'Partner'
+				? sanitizePartnerEquipmentInput(getDefaultPartnerStation(exercises.length))
+				: mode === 'Chipper'
+					? sanitizeChipperStep(
+							createDefaultChipperStep(exercises.length, defaultCategory),
+							exercises.length
+						)
+					: sanitizeEquipmentInput(getDefaultIndividualExercise())
+		];
+	}
+
+	function removeExercise(index) {
+		exercises = exercises.filter((_, i) => i !== index);
+	}
+
+	function addExerciseFromLibrary(libraryExercise) {
+		if (!libraryExercise?.name) return;
+
+		const category = sanitizeCategory(libraryExercise.category);
+		const equipment = Array.isArray(libraryExercise.equipment) ? libraryExercise.equipment : [];
+
+		if (mode === 'Partner') {
+			for (let i = 0; i < exercises.length; i += 1) {
+				const station = exercises[i];
+				if (!station.p1.task?.trim?.()) {
+					const updatedStation = sanitizePartnerEquipmentInput({
+						...station,
+						p1: { ...station.p1, task: libraryExercise.name, category, equipment }
+					});
+					exercises = exercises.map((ex, idx) => (idx === i ? updatedStation : ex));
+					return;
+				}
+
+				if (!station.p2.task?.trim?.()) {
+					const updatedStation = sanitizePartnerEquipmentInput({
+						...station,
+						p2: { ...station.p2, task: libraryExercise.name, category, equipment }
+					});
+					exercises = exercises.map((ex, idx) => (idx === i ? updatedStation : ex));
+					return;
+				}
+			}
+
+			const baseStation = getDefaultPartnerStation(exercises.length);
+			const newStation = sanitizePartnerEquipmentInput({
+				...baseStation,
+				p1: {
+					...baseStation.p1,
+					task: libraryExercise.name,
+					category,
+					equipment
+				}
+			});
+			exercises = [...exercises, newStation];
+			return;
+		}
+
+		if (mode === 'Chipper') {
+			for (let i = 0; i < exercises.length; i += 1) {
+				const step = exercises[i];
+				if (!step.name?.trim?.()) {
+					const updatedStep = {
+						...step,
+						name: libraryExercise.name,
+						category
+					};
+					exercises = exercises.map((ex, idx) => (idx === i ? updatedStep : ex));
+					return;
+				}
+			}
+
+			const newStep = sanitizeChipperStep(
+				createDefaultChipperStep(exercises.length, category),
+				exercises.length
+			);
+			newStep.name = libraryExercise.name;
+			newStep.category = category;
+			exercises = [...exercises, newStep];
+			return;
+		}
+
+		const newExercise = sanitizeEquipmentInput({
+			...getDefaultIndividualExercise(),
+			name: libraryExercise.name,
+			category,
+			equipment,
+			description: ''
+		});
+		exercises = [...exercises, newExercise];
+	}
+
+	function validateExercises() {
+		if (mode === 'Partner') {
+			return exercises.some((exercise) => {
+				const stationName = exercise.name?.trim?.();
+				const p1Task = exercise.p1?.task?.trim?.();
+				const p2Task = exercise.p2?.task?.trim?.();
+				return !stationName || !p1Task || !p2Task;
+			});
+		}
+
+		if (mode === 'Chipper') {
+			const hasInvalidStep = exercises.some((step) => hasIncompleteChipperStep(step));
+			const finisherName = chipperFinisher.name?.trim?.();
+			return hasInvalidStep || !finisherName;
+		}
+
+		return exercises.some((exercise) => !exercise.name?.trim?.());
+	}
+
+	$: if (isLibraryOpen && librarySearchInput) {
+		librarySearchInput.focus();
+	}
+
+	function openLibrary() {
+		librarySearchTerm = '';
+		selectedLibraryIds = [];
+		isLibraryOpen = true;
+	}
+
+	function closeLibrary() {
+		isLibraryOpen = false;
+		librarySearchTerm = '';
+		selectedLibraryIds = [];
+	}
+
+	function clearLibrarySearch() {
+		librarySearchTerm = '';
+		librarySearchInput?.focus?.();
+	}
+
+	function toggleLibrarySelection(libraryExerciseId) {
+		if (!libraryExerciseId) return;
+
+		selectedLibraryIds = selectedLibraryIds.includes(libraryExerciseId)
+			? selectedLibraryIds.filter((id) => id !== libraryExerciseId)
+			: [...selectedLibraryIds, libraryExerciseId];
+	}
+
+	function importSelectedExercises() {
+		if (!selectedLibraryIds.length) return;
+
+		const exercisesById = new Map(exerciseLibrary.map((exercise) => [exercise.id, exercise]));
+
+		for (const exerciseId of selectedLibraryIds) {
+			const libraryExercise = exercisesById.get(exerciseId);
+
+			if (libraryExercise) {
+				addExerciseFromLibrary(libraryExercise);
+			}
+		}
+
+		closeLibrary();
+	}
+
+	function handleOverlayKeyDown(event) {
+		if (!isLibraryOpen) return;
+
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			closeLibrary();
+			return;
+		}
+
+		if (
+			event.currentTarget !== window &&
+			event.target === event.currentTarget &&
+			(event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar')
+		) {
+			event.preventDefault();
+			closeLibrary();
+		}
+	}
+
+	async function saveWorkout() {
+		const trimmedTitle = title?.trim?.() ?? '';
+
+		if (!trimmedTitle || validateExercises()) {
+			errorMessage =
+				'Please complete the workout title and all required exercise fields before saving.';
+			successMessage = '';
+			return;
+		}
+
+		const currentUser = get(user);
+		if (!currentUser?.uid) {
+			errorMessage = 'You need to be signed in to create workouts.';
+			successMessage = '';
+			return;
+		}
+
+		isSubmitting = true;
+		errorMessage = '';
+		successMessage = '';
+
+		try {
+			let normalizedExercises = [];
+			let chipperPayload = null;
+
+			if (mode === 'Partner') {
+				normalizedExercises = exercises.map((exercise, index) => ({
+					name: exercise.name?.trim?.() || `Station ${index + 1}`,
+					p1: {
+						task: exercise.p1?.task?.trim?.() ?? '',
+						category: sanitizeCategory(exercise.p1?.category),
+						equipment: normalizeEquipmentList(
+							typeof exercise.p1?.equipmentInput === 'string'
+								? exercise.p1.equipmentInput
+								: exercise.p1?.equipment
+						)
+					},
+					p2: {
+						task: exercise.p2?.task?.trim?.() ?? '',
+						category: sanitizeCategory(exercise.p2?.category),
+						equipment: normalizeEquipmentList(
+							typeof exercise.p2?.equipmentInput === 'string'
+								? exercise.p2.equipmentInput
+								: exercise.p2?.equipment
+						)
+					},
+					startsOn: normalizeStartsOn(exercise.startsOn)
+				}));
+			} else if (mode === 'Chipper') {
+				const steps = normaliseChipperSteps(exercises, sanitizeCategory);
+				const finisher = sanitizeFinisher(chipperFinisher);
+				chipperPayload = {
+					steps,
+					finisher
+				};
+
+				normalizedExercises = [
+					{
+						name: finisher.name?.trim?.() || 'Max Calories',
+						description:
+							finisher.description?.trim?.() || 'Max calories until the clock hits zero.',
+						category: sanitizeCategory(finisher.category),
+						isFinisher: true,
+						metric: 'Calories'
+					}
+				];
+			} else {
+				normalizedExercises = exercises.map((exercise) => {
+					const entry = sanitizeEquipmentInput(exercise);
+					return {
+						name: entry.name?.trim?.() ?? '',
+						description: entry.description?.trim?.() ?? '',
+						category: sanitizeCategory(entry.category),
+						equipment: entry.equipment
+					};
+				});
+			}
+
+			const emomPayload = type === 'EMOM' ? sanitizeEmomSettings(emomSettings) : null;
+
+			const workoutData = {
+				title: trimmedTitle,
+				type,
+				mode,
+				isBenchmark,
+				notes: notes?.trim?.() ?? '',
+				exercises: normalizedExercises,
+				chipper: chipperPayload,
+				emom: emomPayload,
+				creatorId: currentUser.uid,
+				createdAt: serverTimestamp(),
+				updatedAt: serverTimestamp()
+			};
+
+			await addDoc(collection(db, 'workouts'), workoutData);
+
+			const namesToPersist =
+				mode === 'Partner'
+					? normalizedExercises.flatMap((exercise) => [exercise.p1.task, exercise.p2.task])
+					: mode === 'Chipper'
+						? [
+								...new Set([
+									...chipperPayload.steps.map((step) => step.name),
+									chipperPayload.finisher?.name ?? ''
+								])
+							]
+						: normalizedExercises.map((exercise) => exercise.name);
+
+			for (const rawName of namesToPersist) {
+				const exerciseName = rawName?.trim?.();
+				if (!exerciseName) continue;
+
+				const exerciseRef = doc(db, 'exercises', exerciseName.toLowerCase());
+				await setDoc(exerciseRef, { name: exerciseName }, { merge: true });
+			}
+
+			successMessage = 'Workout created successfully! Redirecting...';
+			setTimeout(() => goto(workoutsUrl), 1200);
+		} catch (error) {
+			console.error('Error saving workout: ', error);
+			errorMessage = 'Failed to save workout. Please try again.';
+		} finally {
+			isSubmitting = false;
+		}
+	}
 </script>
 
 <svelte:window on:keydown={handleOverlayKeyDown} />
 
 <div class="form-container">
-  {#if isLibraryOpen}
-    <div
-      class="modal-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Exercise library"
-      tabindex="0"
-      on:click|self={closeLibrary}
-      on:keydown={handleOverlayKeyDown}
-    >
-      <div class="modal-content" role="document">
-        <header class="modal-header">
-          <h2>Add from Exercise Library</h2>
-          <button type="button" class="close-btn" on:click={closeLibrary}>&times;</button>
-        </header>
-        <div class="library-toolbar">
-          <div class="search-bar">
-            <svg
-              class="search-icon"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                d="M15.5 14h-.79l-.28-.27a6 6 0 1 0-.71.71l.27.28v.79l4.75 4.74a1 1 0 0 0 1.41-1.41zm-5.5 0a4 4 0 1 1 0-8 4 4 0 0 1 0 8"
-              />
-            </svg>
-            <input
-              type="search"
-              bind:value={librarySearchTerm}
-              placeholder="Search exercises..."
-              aria-label="Search exercises"
-              bind:this={librarySearchInput}
-            />
-            {#if librarySearchTerm.trim().length}
-              <button
-                type="button"
-                class="clear-search"
-                on:click={clearLibrarySearch}
-                aria-label="Clear search term"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            {/if}
-          </div>
+	{#if isLibraryOpen}
+		<div
+			class="modal-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Exercise library"
+			tabindex="0"
+			on:click|self={closeLibrary}
+			on:keydown={handleOverlayKeyDown}
+		>
+			<div class="modal-content" role="document">
+				<header class="modal-header">
+					<h2>Add from Exercise Library</h2>
+					<button type="button" class="close-btn" on:click={closeLibrary}>&times;</button>
+				</header>
+				<div class="library-toolbar">
+					<div class="search-bar">
+						<svg
+							class="search-icon"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								fill="currentColor"
+								d="M15.5 14h-.79l-.28-.27a6 6 0 1 0-.71.71l.27.28v.79l4.75 4.74a1 1 0 0 0 1.41-1.41zm-5.5 0a4 4 0 1 1 0-8 4 4 0 0 1 0 8"
+							/>
+						</svg>
+						<input
+							type="search"
+							bind:value={librarySearchTerm}
+							placeholder="Search exercises..."
+							aria-label="Search exercises"
+							bind:this={librarySearchInput}
+						/>
+						{#if librarySearchTerm.trim().length}
+							<button
+								type="button"
+								class="clear-search"
+								on:click={clearLibrarySearch}
+								aria-label="Clear search term"
+							>
+								<span aria-hidden="true">&times;</span>
+							</button>
+						{/if}
+					</div>
 
-          <span class="result-count" aria-live="polite">
-            {#if librarySearchTerm.trim().length === 0}
-              {exerciseLibrary.length} exercises available
-            {:else if filteredLibrary.length === 0}
-              No matches
-            {:else}
-              {filteredLibrary.length} match{filteredLibrary.length === 1 ? '' : 'es'}
-            {/if}
-          </span>
-        </div>
+					<span class="result-count" aria-live="polite">
+						{#if librarySearchTerm.trim().length === 0}
+							{exerciseLibrary.length} exercises available
+						{:else if filteredLibrary.length === 0}
+							No matches
+						{:else}
+							{filteredLibrary.length} match{filteredLibrary.length === 1 ? '' : 'es'}
+						{/if}
+					</span>
+				</div>
 
-        {#if filteredLibrary.length === 0}
-          <p class="empty-state">No exercises found. Try a different search.</p>
-        {:else}
-          <div class="library-grid">
-            {#each filteredLibrary as libraryExercise (libraryExercise.id)}
-              {@const isSelected = selectedLibraryIds.includes(libraryExercise.id)}
-              <button
-                type="button"
-                class="library-item"
-                class:selected={isSelected}
-                aria-pressed={isSelected}
-                on:click={() => toggleLibrarySelection(libraryExercise.id)}
-              >
-                <div class="library-item-header">
-                  <span class="library-item-checkbox" aria-hidden="true">
-                    {#if isSelected}
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M16.704 5.29a1 1 0 0 1 0 1.42l-7.2 7.19a1 1 0 0 1-1.414 0l-3.2-3.19a1 1 0 1 1 1.414-1.42l2.493 2.48 6.493-6.48a1 1 0 0 1 1.414 0Z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    {/if}
-                  </span>
-                  <span class="library-item-name">{libraryExercise.name}</span>
-                </div>
-                <span class="library-item-category">{libraryExercise.category}</span>
-                {#if libraryExercise.equipment?.length}
-                  <span class="library-item-equipment">
-                    {libraryExercise.equipment.join(', ')}
-                  </span>
-                {/if}
-              </button>
-            {/each}
-          </div>
-          <div class="library-footer">
-            <span class="selection-count" aria-live="polite">
-              {#if selectedLibraryIds.length === 0}
-                No exercises selected
-              {:else if selectedLibraryIds.length === 1}
-                1 exercise selected
-              {:else}
-                {selectedLibraryIds.length} exercises selected
-              {/if}
-            </span>
-            <button
-              type="button"
-              class="primary-btn import-btn"
-              on:click={importSelectedExercises}
-              disabled={!selectedLibraryIds.length}
-            >
-              Add Selected
-            </button>
-          </div>
-        {/if}
-      </div>
-    </div>
-  {/if}
+				{#if filteredLibrary.length === 0}
+					<p class="empty-state">No exercises found. Try a different search.</p>
+				{:else}
+					<div class="library-grid">
+						{#each filteredLibrary as libraryExercise (libraryExercise.id)}
+							{@const isSelected = selectedLibraryIds.includes(libraryExercise.id)}
+							<button
+								type="button"
+								class="library-item"
+								class:selected={isSelected}
+								aria-pressed={isSelected}
+								on:click={() => toggleLibrarySelection(libraryExercise.id)}
+							>
+								<div class="library-item-header">
+									<span class="library-item-checkbox" aria-hidden="true">
+										{#if isSelected}
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 20 20"
+												fill="currentColor"
+											>
+												<path
+													fill-rule="evenodd"
+													d="M16.704 5.29a1 1 0 0 1 0 1.42l-7.2 7.19a1 1 0 0 1-1.414 0l-3.2-3.19a1 1 0 1 1 1.414-1.42l2.493 2.48 6.493-6.48a1 1 0 0 1 1.414 0Z"
+													clip-rule="evenodd"
+												/>
+											</svg>
+										{/if}
+									</span>
+									<span class="library-item-name">{libraryExercise.name}</span>
+								</div>
+								<span class="library-item-category">{libraryExercise.category}</span>
+								{#if libraryExercise.equipment?.length}
+									<span class="library-item-equipment">
+										{libraryExercise.equipment.join(', ')}
+									</span>
+								{/if}
+							</button>
+						{/each}
+					</div>
+					<div class="library-footer">
+						<span class="selection-count" aria-live="polite">
+							{#if selectedLibraryIds.length === 0}
+								No exercises selected
+							{:else if selectedLibraryIds.length === 1}
+								1 exercise selected
+							{:else}
+								{selectedLibraryIds.length} exercises selected
+							{/if}
+						</span>
+						<button
+							type="button"
+							class="primary-btn import-btn"
+							on:click={importSelectedExercises}
+							disabled={!selectedLibraryIds.length}
+						>
+							Add Selected
+						</button>
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
 
-  <h1>Create New Workout</h1>
-  <form on:submit|preventDefault={saveWorkout}>
-    <div class="form-group">
-      <label for="title">Workout Title</label>
-      <input id="title" type="text" bind:value={title} required />
-    </div>
+	<header class="builder-hero">
+		<p class="eyebrow">Workout builder</p>
+		<h1>Create New Workout</h1>
+		<p>
+			Build client-ready sessions faster with clearer sections, library shortcuts and station cards.
+		</p>
+	</header>
+	<form on:submit|preventDefault={saveWorkout}>
+		<div class="form-group">
+			<label for="title">Workout Title</label>
+			<input id="title" type="text" bind:value={title} required />
+		</div>
 
-    <div class="split-group">
-      <div class="form-group">
-        <label for="type">Workout Type</label>
-        <select id="type" bind:value={type}>
-          <option>Circuit</option>
-          <option>AMRAP</option>
-          <option>EMOM</option>
-          <option>Timed Rounds</option>
-          <option>For Time</option>
-        </select>
-      </div>
+		<div class="split-group">
+			<div class="form-group">
+				<label for="type">Workout Type</label>
+				<select id="type" bind:value={type}>
+					<option>Circuit</option>
+					<option>AMRAP</option>
+					<option>EMOM</option>
+					<option>Timed Rounds</option>
+					<option>For Time</option>
+				</select>
+			</div>
 
-      <div class="form-group">
-        <label for="mode">Participation Mode</label>
-        <select id="mode" bind:value={mode}>
-          <option>Individual</option>
-          <option>Partner</option>
-          <option>Chipper</option>
-        </select>
-      </div>
-    </div>
+			<div class="form-group">
+				<label for="mode">Participation Mode</label>
+				<select id="mode" bind:value={mode}>
+					<option>Individual</option>
+					<option>Partner</option>
+					<option>Chipper</option>
+				</select>
+			</div>
+		</div>
 
-    <div class="form-group">
-      <label for="notes">Notes / Instructions</label>
-      <textarea id="notes" bind:value={notes} rows="3" placeholder="Coaching notes, setup reminders, etc."></textarea>
-    </div>
+		<div class="form-group">
+			<label for="notes">Notes / Instructions</label>
+			<textarea
+				id="notes"
+				bind:value={notes}
+				rows="3"
+				placeholder="Coaching notes, setup reminders, etc."
+			></textarea>
+		</div>
 
-    {#if type === 'EMOM'}
-      <section class="emom-settings">
-        <header>
-          <h2>EMOM Recovery Blocks</h2>
-          <p class="input-hint">
-            Add an automatic recovery minute after a set number of work intervals. Leave both values blank to
-            skip the rest period.
-          </p>
-        </header>
-        <div class="emom-grid">
-          <div class="form-group">
-            <label for="emom-rest-every">Rest every (minutes)</label>
-            <input
-              id="emom-rest-every"
-              type="number"
-              min="0"
-              inputmode="numeric"
-              bind:value={emomSettings.restEvery}
-              placeholder="e.g. 5"
-            />
-          </div>
-          <div class="form-group">
-            <label for="emom-rest-duration">Recovery duration (seconds)</label>
-            <input
-              id="emom-rest-duration"
-              type="number"
-              min="0"
-              inputmode="numeric"
-              bind:value={emomSettings.restDuration}
-              placeholder="e.g. 60"
-            />
-          </div>
-          <div class="form-group">
-            <label for="emom-rest-label">Recovery label</label>
-            <input
-              id="emom-rest-label"
-              type="text"
-              bind:value={emomSettings.restLabel}
-              placeholder="Recovery Minute"
-            />
-          </div>
-        </div>
-        <p class="input-hint subtle">
-          When both fields are set we'll insert a recovery interval between the matching minutes without affecting
-          other workout types.
-        </p>
-      </section>
-    {/if}
+		{#if type === 'EMOM'}
+			<section class="emom-settings">
+				<header>
+					<h2>EMOM Recovery Blocks</h2>
+					<p class="input-hint">
+						Add an automatic recovery minute after a set number of work intervals. Leave both values
+						blank to skip the rest period.
+					</p>
+				</header>
+				<div class="emom-grid">
+					<div class="form-group">
+						<label for="emom-rest-every">Rest every (minutes)</label>
+						<input
+							id="emom-rest-every"
+							type="number"
+							min="0"
+							inputmode="numeric"
+							bind:value={emomSettings.restEvery}
+							placeholder="e.g. 5"
+						/>
+					</div>
+					<div class="form-group">
+						<label for="emom-rest-duration">Recovery duration (seconds)</label>
+						<input
+							id="emom-rest-duration"
+							type="number"
+							min="0"
+							inputmode="numeric"
+							bind:value={emomSettings.restDuration}
+							placeholder="e.g. 60"
+						/>
+					</div>
+					<div class="form-group">
+						<label for="emom-rest-label">Recovery label</label>
+						<input
+							id="emom-rest-label"
+							type="text"
+							bind:value={emomSettings.restLabel}
+							placeholder="Recovery Minute"
+						/>
+					</div>
+				</div>
+				<p class="input-hint subtle">
+					When both fields are set we'll insert a recovery interval between the matching minutes
+					without affecting other workout types.
+				</p>
+			</section>
+		{/if}
 
-    <div class="form-group-checkbox">
-      <input id="benchmark" type="checkbox" bind:checked={isBenchmark} />
-      <label for="benchmark">Make this a Benchmark Workout</label>
-    </div>
+		<div class="form-group-checkbox">
+			<input id="benchmark" type="checkbox" bind:checked={isBenchmark} />
+			<label for="benchmark">Make this a Benchmark Workout</label>
+		</div>
 
-    <fieldset>
-      <legend>Exercises</legend>
-      <p class="input-hint">
-        Use the exercise library for quick selections or add stations manually. Station names and tasks are required.
-      </p>
+		<fieldset>
+			<legend>Exercises</legend>
+			<p class="input-hint">
+				Use the exercise library for quick selections or add stations manually. Station names and
+				tasks are required.
+			</p>
 
-      <datalist id="exercise-suggestions">
-        {#each allExerciseNames as exerciseName}
-          <option value={exerciseName}></option>
-        {/each}
-      </datalist>
+			<datalist id="exercise-suggestions">
+				{#each allExerciseNames as exerciseName}
+					<option value={exerciseName}></option>
+				{/each}
+			</datalist>
 
-      {#if mode === 'Partner'}
-        {#each exercises as exercise, index}
-          <div class="station-editor-card">
-            <div class="station-editor-header">
-              <input
-                class="station-name-input"
-                type="text"
-                bind:value={exercise.name}
-                placeholder={`Station ${index + 1}`}
-                required
-              />
-              <button type="button" class="remove-btn" on:click={() => removeExercise(index)}>&times;</button>
-            </div>
+			{#if mode === 'Partner'}
+				{#each exercises as exercise, index}
+					<div class="station-editor-card">
+						<div class="station-editor-header">
+							<input
+								class="station-name-input"
+								type="text"
+								bind:value={exercise.name}
+								placeholder={`Station ${index + 1}`}
+								required
+							/>
+							<button type="button" class="remove-btn" on:click={() => removeExercise(index)}
+								>&times;</button
+							>
+						</div>
 
-            <div class="partner-grid">
-              <div class="partner-column">
-                <label for={`p1-task-${index}`}>Partner A Task</label>
-                <input
-                  id={`p1-task-${index}`}
-                  type="text"
-                  bind:value={exercise.p1.task}
-                  required
-                  list="exercise-suggestions"
-                />
-                <label for={`p1-cat-${index}`}>Category</label>
-                <select id={`p1-cat-${index}`} bind:value={exercise.p1.category}>
-                  {#each categoryOptions as option}
-                    <option>{option}</option>
-                  {/each}
-                </select>
-              </div>
+						<div class="partner-grid">
+							<div class="partner-column">
+								<label for={`p1-task-${index}`}>Partner A Task</label>
+								<input
+									id={`p1-task-${index}`}
+									type="text"
+									bind:value={exercise.p1.task}
+									required
+									list="exercise-suggestions"
+								/>
+								<label for={`p1-cat-${index}`}>Category</label>
+								<select id={`p1-cat-${index}`} bind:value={exercise.p1.category}>
+									{#each categoryOptions as option}
+										<option>{option}</option>
+									{/each}
+								</select>
+							</div>
 
-              <div class="partner-column">
-                <label for={`p2-task-${index}`}>Partner B Task</label>
-                <input
-                  id={`p2-task-${index}`}
-                  type="text"
-                  bind:value={exercise.p2.task}
-                  required
-                  list="exercise-suggestions"
-                />
-                <label for={`p2-cat-${index}`}>Category</label>
-                <select id={`p2-cat-${index}`} bind:value={exercise.p2.category}>
-                  {#each categoryOptions as option}
-                    <option>{option}</option>
-                  {/each}
-                </select>
-              </div>
-            </div>
+							<div class="partner-column">
+								<label for={`p2-task-${index}`}>Partner B Task</label>
+								<input
+									id={`p2-task-${index}`}
+									type="text"
+									bind:value={exercise.p2.task}
+									required
+									list="exercise-suggestions"
+								/>
+								<label for={`p2-cat-${index}`}>Category</label>
+								<select id={`p2-cat-${index}`} bind:value={exercise.p2.category}>
+									{#each categoryOptions as option}
+										<option>{option}</option>
+									{/each}
+								</select>
+							</div>
+						</div>
 
-            <div class="starter-select">
-              <p class="starter-label">Who starts this station?</p>
-              <div class="radio-group">
-                <label>
-                  <input type="radio" bind:group={exercise.startsOn} value="P1" /> Partner A
-                </label>
-                <label>
-                  <input type="radio" bind:group={exercise.startsOn} value="P2" /> Partner B
-                </label>
-              </div>
-            </div>
-          </div>
-        {/each}
-      {:else if mode === 'Chipper'}
-        <div class="chipper-editor">
-          <header class="chipper-heading">
-            <h3>Chipper sequence</h3>
-            <p>List the movements in order. We'll display them as an inverted pyramid on the live timer.</p>
-          </header>
+						<div class="starter-select">
+							<p class="starter-label">Who starts this station?</p>
+							<div class="radio-group">
+								<label>
+									<input type="radio" bind:group={exercise.startsOn} value="P1" /> Partner A
+								</label>
+								<label>
+									<input type="radio" bind:group={exercise.startsOn} value="P2" /> Partner B
+								</label>
+							</div>
+						</div>
+					</div>
+				{/each}
+			{:else if mode === 'Chipper'}
+				<div class="chipper-editor">
+					<header class="chipper-heading">
+						<h3>Chipper sequence</h3>
+						<p>
+							List the movements in order. We'll display them as an inverted pyramid on the live
+							timer.
+						</p>
+					</header>
 
-          <div class="chipper-grid chipper-grid-header" aria-hidden="true">
-            <span>Movement</span>
-            <span>Reps</span>
-            <span>Category</span>
-          </div>
+					<div class="chipper-grid chipper-grid-header" aria-hidden="true">
+						<span>Movement</span>
+						<span>Reps</span>
+						<span>Category</span>
+					</div>
 
-          {#each exercises as step, index}
-            <div class="chipper-grid">
-              <div class="chipper-movement">
-                <span class="chipper-index" aria-hidden="true">#{index + 1}</span>
-                <label class="sr-only" for={`chipper-move-${index}`}>Movement {index + 1}</label>
-                <input
-                  id={`chipper-move-${index}`}
-                  type="text"
-                  bind:value={step.name}
-                  placeholder={`Exercise #${index + 1}`}
-                  required
-                  list="exercise-suggestions"
-                />
-              </div>
-              <div class="chipper-reps">
-                <label class="sr-only" for={`chipper-reps-${index}`}>Repetitions for movement {index + 1}</label>
-                <input
-                  id={`chipper-reps-${index}`}
-                  type="number"
-                  min="1"
-                  inputmode="numeric"
-                  bind:value={step.reps}
-                  required
-                />
-              </div>
-              <div class="chipper-category">
-                <label class="sr-only" for={`chipper-cat-${index}`}>Category for movement {index + 1}</label>
-                <select id={`chipper-cat-${index}`} bind:value={step.category}>
-                  {#each categoryOptions as option}
-                    <option>{option}</option>
-                  {/each}
-                </select>
-              </div>
-              <button
-                type="button"
-                class="remove-btn"
-                on:click={() => removeExercise(index)}
-                aria-label={`Remove movement ${index + 1}`}
-              >
-                &times;
-              </button>
-            </div>
-          {/each}
+					{#each exercises as step, index}
+						<div class="chipper-grid">
+							<div class="chipper-movement">
+								<span class="chipper-index" aria-hidden="true">#{index + 1}</span>
+								<label class="sr-only" for={`chipper-move-${index}`}>Movement {index + 1}</label>
+								<input
+									id={`chipper-move-${index}`}
+									type="text"
+									bind:value={step.name}
+									placeholder={`Exercise #${index + 1}`}
+									required
+									list="exercise-suggestions"
+								/>
+							</div>
+							<div class="chipper-reps">
+								<label class="sr-only" for={`chipper-reps-${index}`}
+									>Repetitions for movement {index + 1}</label
+								>
+								<input
+									id={`chipper-reps-${index}`}
+									type="number"
+									min="1"
+									inputmode="numeric"
+									bind:value={step.reps}
+									required
+								/>
+							</div>
+							<div class="chipper-category">
+								<label class="sr-only" for={`chipper-cat-${index}`}
+									>Category for movement {index + 1}</label
+								>
+								<select id={`chipper-cat-${index}`} bind:value={step.category}>
+									{#each categoryOptions as option}
+										<option>{option}</option>
+									{/each}
+								</select>
+							</div>
+							<button
+								type="button"
+								class="remove-btn"
+								on:click={() => removeExercise(index)}
+								aria-label={`Remove movement ${index + 1}`}
+							>
+								&times;
+							</button>
+						</div>
+					{/each}
 
-          <div class="chipper-finisher">
-            <h4>Finisher</h4>
-            <p>
-              Once the chipper is complete, athletes head straight into this effort and log their calories on the live timer.
-            </p>
-            <div class="finisher-grid">
-              <div class="finisher-name">
-                <label for="finisher-name">Finisher name</label>
-                <input
-                  id="finisher-name"
-                  type="text"
-                  bind:value={chipperFinisher.name}
-                  placeholder="Max Calories"
-                  required
-                />
-              </div>
-              <div class="finisher-category">
-                <label for="finisher-category">Category</label>
-                <select id="finisher-category" bind:value={chipperFinisher.category}>
-                  {#each categoryOptions as option}
-                    <option>{option}</option>
-                  {/each}
-                </select>
-              </div>
-            </div>
-            <label for="finisher-notes" class="finisher-notes-label">Description (optional)</label>
-            <input
-              id="finisher-notes"
-              type="text"
-              bind:value={chipperFinisher.description}
-              placeholder="E.g. Max calories on the Echo Bike"
-            />
-          </div>
-        </div>
-      {:else}
-        {#each exercises as exercise, index}
-          <div class="exercise-item">
-            <input
-              type="text"
-              bind:value={exercise.name}
-              placeholder={`Exercise #${index + 1}`}
-              required
-              list="exercise-suggestions"
-            />
-            <select bind:value={exercise.category}>
-              {#each categoryOptions as option}
-                <option>{option}</option>
-              {/each}
-            </select>
-            <input
-              type="text"
-              bind:value={exercise.description}
-              placeholder="Description (e.g., 12 reps, 45s)"
-            />
-            {#if type === 'EMOM' && ['Cardio Machine', 'Bodyweight'].includes(exercise.category)}
-              <input
-                type="text"
-                class="equipment-input"
-                bind:value={exercise.equipmentInput}
-                placeholder="Equipment options (comma separated)"
-              />
-              <p class="input-hint equipment-hint">
-                Members will pick the machine or variation they used during the minute.
-              </p>
-            {/if}
-            <button type="button" class="remove-btn" on:click={() => removeExercise(index)}>&times;</button>
-          </div>
-        {/each}
-      {/if}
+					<div class="chipper-finisher">
+						<h4>Finisher</h4>
+						<p>
+							Once the chipper is complete, athletes head straight into this effort and log their
+							calories on the live timer.
+						</p>
+						<div class="finisher-grid">
+							<div class="finisher-name">
+								<label for="finisher-name">Finisher name</label>
+								<input
+									id="finisher-name"
+									type="text"
+									bind:value={chipperFinisher.name}
+									placeholder="Max Calories"
+									required
+								/>
+							</div>
+							<div class="finisher-category">
+								<label for="finisher-category">Category</label>
+								<select id="finisher-category" bind:value={chipperFinisher.category}>
+									{#each categoryOptions as option}
+										<option>{option}</option>
+									{/each}
+								</select>
+							</div>
+						</div>
+						<label for="finisher-notes" class="finisher-notes-label">Description (optional)</label>
+						<input
+							id="finisher-notes"
+							type="text"
+							bind:value={chipperFinisher.description}
+							placeholder="E.g. Max calories on the Echo Bike"
+						/>
+					</div>
+				</div>
+			{:else}
+				{#each exercises as exercise, index}
+					<div class="exercise-item">
+						<input
+							type="text"
+							bind:value={exercise.name}
+							placeholder={`Exercise #${index + 1}`}
+							required
+							list="exercise-suggestions"
+						/>
+						<select bind:value={exercise.category}>
+							{#each categoryOptions as option}
+								<option>{option}</option>
+							{/each}
+						</select>
+						<input
+							type="text"
+							bind:value={exercise.description}
+							placeholder="Description (e.g., 12 reps, 45s)"
+						/>
+						{#if type === 'EMOM' && ['Cardio Machine', 'Bodyweight'].includes(exercise.category)}
+							<input
+								type="text"
+								class="equipment-input"
+								bind:value={exercise.equipmentInput}
+								placeholder="Equipment options (comma separated)"
+							/>
+							<p class="input-hint equipment-hint">
+								Members will pick the machine or variation they used during the minute.
+							</p>
+						{/if}
+						<button type="button" class="remove-btn" on:click={() => removeExercise(index)}
+							>&times;</button
+						>
+					</div>
+				{/each}
+			{/if}
 
-      <div class="exercise-actions">
-        <button type="button" class="secondary-btn" on:click={addExercise}>
-          {mode === 'Partner' ? '+ Add Station' : mode === 'Chipper' ? '+ Add Movement' : '+ Add Exercise'}
-        </button>
-        <button
-          type="button"
-          class="primary-btn library-btn"
-          on:click={openLibrary}
-        >
-          + Add from Library
-        </button>
-      </div>
-    </fieldset>
+			<div class="exercise-actions">
+				<button type="button" class="secondary-btn" on:click={addExercise}>
+					{mode === 'Partner'
+						? '+ Add Station'
+						: mode === 'Chipper'
+							? '+ Add Movement'
+							: '+ Add Exercise'}
+				</button>
+				<button type="button" class="primary-btn library-btn" on:click={openLibrary}>
+					+ Add from Library
+				</button>
+			</div>
+		</fieldset>
 
-    {#if successMessage}
-      <p class="success-message">{successMessage}</p>
-    {/if}
-    {#if errorMessage}
-      <p class="error-message">{errorMessage}</p>
-    {/if}
+		{#if successMessage}
+			<p class="success-message">{successMessage}</p>
+		{/if}
+		{#if errorMessage}
+			<p class="error-message">{errorMessage}</p>
+		{/if}
 
-    <button type="submit" class="primary-btn submit-btn" disabled={isSubmitting}>
-      {isSubmitting ? 'Saving...' : 'Save Workout'}
-    </button>
-  </form>
+		<button type="submit" class="primary-btn submit-btn" disabled={isSubmitting}>
+			{isSubmitting ? 'Saving...' : 'Save Workout'}
+		</button>
+	</form>
 </div>
 
 <style>
-  .form-container {
-    width: 100%;
-    max-width: 760px;
-    margin: 2rem auto;
-    padding: 2rem;
-    background: var(--surface-1);
-    border: 1px solid var(--border-color);
-    border-radius: 16px;
-  }
-
-  h1 {
-    font-family: var(--font-display);
-    color: var(--brand-yellow);
-    text-align: center;
-    margin-bottom: 1.5rem;
-  }
-
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-  }
-
-  .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .split-group {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .emom-settings {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1.5rem;
-    background: var(--deep-space);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-  }
-
-  .emom-settings h2 {
-    margin: 0;
-    font-size: 1.25rem;
-  }
-
-  .emom-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-  }
-
-  .input-hint.subtle {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-  }
-
-  .equipment-input {
-    margin-top: 0.5rem;
-  }
-
-  .equipment-hint {
-    margin-top: -0.35rem;
-    font-size: 0.8rem;
-  }
-
-  .split-group .form-group {
-    flex: 1 1 220px;
-  }
-
-  .form-group-checkbox {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  input[type='text'],
-  input[type='search'],
-  select,
-  textarea {
-    width: 100%;
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    background: var(--deep-space);
-    color: var(--text-primary);
-    padding: 0.75rem;
-    font-size: 1rem;
-  }
-
-  textarea {
-    resize: vertical;
-  }
-
-  fieldset {
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-  }
-
-  legend {
-    font-weight: 600;
-    padding: 0 0.5rem;
-    color: var(--text-muted);
-  }
-
-  .input-hint {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    margin: 0;
-  }
-
-  .chipper-editor {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    background: var(--deep-space);
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    padding: 1.5rem;
-  }
-
-  .chipper-heading h3 {
-    margin: 0;
-    font-size: 1.25rem;
-  }
-
-  .chipper-heading p {
-    margin: 0.25rem 0 0;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-  }
-
-  .chipper-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 120px 180px auto;
-    gap: 0.75rem;
-    align-items: center;
-  }
-
-  .chipper-grid + .chipper-grid {
-    border-top: 1px solid var(--border-color);
-    padding-top: 0.85rem;
-    margin-top: 0.85rem;
-  }
-
-  .chipper-grid-header {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--text-muted);
-    border-bottom: 1px solid var(--border-color);
-    padding-bottom: 0.35rem;
-  }
-
-  .chipper-grid-header span:last-child {
-    justify-self: center;
-  }
-
-  .chipper-movement {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .chipper-index {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 999px;
-    background: var(--surface-1);
-    color: var(--text-muted);
-    font-weight: 600;
-    font-size: 0.9rem;
-  }
-
-  .chipper-movement input {
-    flex: 1;
-  }
-
-  .chipper-reps input {
-    text-align: center;
-  }
-
-  .chipper-category select {
-    width: 100%;
-  }
-
-  .chipper-finisher {
-    border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .chipper-finisher h4 {
-    margin: 0;
-    font-size: 1.1rem;
-  }
-
-  .chipper-finisher p {
-    margin: 0;
-    color: var(--text-muted);
-    font-size: 0.9rem;
-  }
-
-  .finisher-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(140px, 220px);
-    gap: 1rem;
-  }
-
-  .finisher-grid label {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    display: block;
-    margin-bottom: 0.35rem;
-  }
-
-  .finisher-name input,
-  .finisher-category select,
-  #finisher-notes {
-    width: 100%;
-  }
-
-  .finisher-notes-label {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-  }
-
-  .exercise-item {
-    display: grid;
-    grid-template-columns: 2fr 1fr 2fr auto;
-    gap: 0.75rem;
-    align-items: center;
-  }
-
-  .station-editor-card {
-    background: var(--deep-space);
-    border-radius: 12px;
-    border: 1px solid var(--border-color);
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .station-editor-header {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-
-  .station-name-input {
-    flex: 1;
-    font-size: 1.1rem;
-    font-weight: 600;
-    border: none;
-    border-bottom: 2px solid var(--border-color);
-    background: transparent;
-    color: var(--text-primary);
-    padding-bottom: 0.35rem;
-  }
-
-  .partner-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem;
-  }
-
-  .partner-column {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .starter-select {
-    border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
-  }
-
-  .starter-label {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-  }
-
-  .radio-group {
-    display: flex;
-    gap: 1.5rem;
-  }
-
-  .remove-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0 0.35rem;
-  }
-
-  .remove-btn:hover {
-    color: var(--brand-yellow);
-  }
-
-  .exercise-actions {
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .secondary-btn,
-  .primary-btn {
-    border: none;
-    border-radius: 999px;
-    padding: 0.85rem 1.5rem;
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  .secondary-btn {
-    background: transparent;
-    border: 1px solid var(--border-color);
-    color: var(--text-primary);
-  }
-
-  .secondary-btn:hover {
-    border-color: var(--brand-yellow);
-    color: var(--brand-yellow);
-  }
-
-  .primary-btn {
-    background: var(--brand-green);
-    color: var(--deep-space);
-  }
-
-  .library-btn {
-    background: var(--brand-yellow);
-    color: var(--deep-space);
-  }
-
-  .submit-btn {
-    align-self: flex-end;
-    padding: 1rem 2.5rem;
-    font-size: 1.1rem;
-  }
-
-  .primary-btn:disabled {
-    opacity: 0.65;
-    cursor: not-allowed;
-  }
-
-  .success-message {
-    color: var(--brand-green);
-    font-weight: 600;
-  }
-
-  .error-message {
-    color: #f87171;
-    font-weight: 600;
-  }
-
-  .modal-overlay {
-    position: fixed;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(5, 8, 15, 0.78);
-    backdrop-filter: blur(4px);
-    padding: clamp(1.5rem, 4vw, 3rem);
-    z-index: 10;
-  }
-
-  @media (max-width: 720px) {
-    .chipper-grid {
-      grid-template-columns: 1fr;
-      gap: 0.5rem;
-    }
-
-    .chipper-grid-header {
-      display: none;
-    }
-
-    .chipper-movement {
-      justify-content: flex-start;
-    }
-
-    .chipper-index {
-      width: 28px;
-      height: 28px;
-      font-size: 0.8rem;
-    }
-
-    .remove-btn {
-      justify-self: flex-start;
-      padding-left: 0;
-    }
-
-    .finisher-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .modal-content {
-    width: min(720px, 100%);
-    background: var(--surface-1);
-    border-radius: 18px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    padding: clamp(1.5rem, 4vw, 2.25rem);
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    position: relative;
-    box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
-    max-height: min(720px, calc(100vh - 4rem));
-    overflow: hidden;
-  }
-
-  .modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-  }
-
-  .close-btn {
-    background: none;
-    border: none;
-    color: var(--text-muted);
-    font-size: 1.75rem;
-    cursor: pointer;
-  }
-
-  .close-btn:hover {
-    color: var(--brand-yellow);
-  }
-
-  .library-toolbar {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: stretch;
-  }
-
-  .search-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    border-radius: 999px;
-    border: 1px solid var(--border-color);
-    background: rgba(17, 23, 34, 0.85);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .search-bar:focus-within {
-    border-color: var(--brand-yellow);
-    box-shadow: 0 0 0 3px rgba(247, 224, 120, 0.18);
-  }
-
-  .search-bar input {
-    flex: 1;
-    background: transparent;
-    border: none;
-    color: var(--text-primary);
-    font-size: 0.95rem;
-    outline: none;
-  }
-
-  .search-bar input::placeholder {
-    color: var(--text-muted);
-  }
-
-  .search-icon {
-    width: 1.1rem;
-    height: 1.1rem;
-    color: var(--text-muted);
-    flex-shrink: 0;
-  }
-
-  .clear-search {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    padding: 0.25rem;
-    border-radius: 999px;
-    cursor: pointer;
-    transition: color 0.2s ease, background 0.2s ease;
-  }
-
-  .clear-search:hover,
-  .clear-search:focus-visible {
-    color: var(--brand-yellow);
-    background: rgba(247, 224, 120, 0.08);
-  }
-
-  .clear-search:focus-visible {
-    outline: 2px solid var(--brand-yellow);
-    outline-offset: 2px;
-  }
-
-  .result-count {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-  }
-
-  @media (min-width: 560px) {
-    .library-toolbar {
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .result-count {
-      text-align: right;
-    }
-  }
-
-  .library-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1rem;
-    max-height: clamp(320px, 55vh, 540px);
-    overflow-y: auto;
-    padding-right: 0.25rem;
-  }
-
-  .library-grid::-webkit-scrollbar {
-    width: 0.4rem;
-  }
-
-  .library-grid::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.12);
-    border-radius: 999px;
-  }
-
-  .library-item {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-    border-radius: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    background: linear-gradient(145deg, rgba(17, 24, 39, 0.92), rgba(17, 24, 39, 0.78));
-    color: var(--text-primary);
-    padding: 1rem;
-    cursor: pointer;
-    text-align: left;
-    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .library-item.selected {
-    border-color: rgba(247, 224, 120, 0.6);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
-  }
-
-  .library-item:hover {
-    border-color: rgba(247, 224, 120, 0.6);
-    transform: translateY(-2px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
-  }
-
-  .library-item:focus-visible {
-    outline: 2px solid var(--brand-yellow);
-    outline-offset: 3px;
-  }
-
-  .library-item-header {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-  }
-
-  .library-item-checkbox {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
-    border-radius: 8px;
-    border: 1.5px solid rgba(255, 255, 255, 0.16);
-    background: rgba(17, 24, 39, 0.75);
-    color: var(--brand-yellow);
-    transition: border-color 0.2s ease, background 0.2s ease;
-  }
-
-  .library-item.selected .library-item-checkbox {
-    border-color: rgba(247, 224, 120, 0.9);
-    background: rgba(247, 224, 120, 0.15);
-  }
-
-  .library-item-checkbox svg {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  .library-item-name {
-    font-weight: 600;
-  }
-
-  .library-item-category {
-    font-size: 0.85rem;
-    color: var(--text-muted);
-  }
-
-  .library-item-equipment {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-  }
-
-  .library-footer {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    margin-top: 1.25rem;
-  }
-
-  .selection-count {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
-
-  .import-btn {
-    align-self: flex-start;
-    padding-inline: 1.75rem;
-  }
-
-  .import-btn:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .empty-state {
-    text-align: center;
-    color: var(--text-muted);
-  }
-
-  @media (max-width: 680px) {
-    .exercise-item {
-      grid-template-columns: 1fr;
-    }
-
-    .exercise-actions {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .submit-btn {
-      width: 100%;
-      align-self: stretch;
-    }
-  }
-
-  @media (min-width: 560px) {
-    .library-footer {
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .import-btn {
-      align-self: unset;
-    }
-  }
+	.form-container {
+		width: min(1120px, 100%);
+		margin: 0 auto;
+		padding: clamp(1rem, 3vw, 2rem);
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(30, 41, 59, 0.58));
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: var(--radius-xl);
+		box-shadow: var(--shadow-card);
+	}
+
+	.builder-hero {
+		margin-bottom: 1.5rem;
+		padding: clamp(1rem, 3vw, 1.5rem);
+		border: 1px solid rgba(250, 204, 21, 0.18);
+		border-radius: 24px;
+		background: rgba(2, 6, 23, 0.32);
+	}
+
+	.eyebrow {
+		color: var(--brand-yellow);
+		font-size: 0.76rem;
+		font-weight: 900;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		font-family: var(--font-display);
+		color: var(--text-primary);
+		font-size: clamp(3rem, 7vw, 5rem);
+		line-height: 0.9;
+		margin: 0.2rem 0 0.45rem;
+	}
+
+	.builder-hero p:last-child {
+		color: var(--text-secondary);
+	}
+
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.split-group {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.emom-settings {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1.5rem;
+		background: var(--deep-space);
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+	}
+
+	.emom-settings h2 {
+		margin: 0;
+		font-size: 1.25rem;
+	}
+
+	.emom-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 1rem;
+	}
+
+	.input-hint.subtle {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.equipment-input {
+		margin-top: 0.5rem;
+	}
+
+	.equipment-hint {
+		margin-top: -0.35rem;
+		font-size: 0.8rem;
+	}
+
+	.split-group .form-group {
+		flex: 1 1 220px;
+	}
+
+	.form-group-checkbox {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	input[type='text'],
+	input[type='search'],
+	input[type='number'],
+	select,
+	textarea {
+		width: 100%;
+		border: 1px solid rgba(226, 232, 240, 0.16);
+		border-radius: 14px;
+		background: rgba(2, 6, 23, 0.58);
+		color: var(--text-primary);
+		padding: 0.85rem 0.95rem;
+		font-size: 1rem;
+		transition:
+			border-color var(--transition),
+			box-shadow var(--transition),
+			background var(--transition);
+	}
+
+	input:focus,
+	select:focus,
+	textarea:focus {
+		border-color: rgba(250, 204, 21, 0.6);
+		outline: none;
+		background: rgba(2, 6, 23, 0.78);
+		box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.12);
+	}
+
+	textarea {
+		resize: vertical;
+	}
+
+	fieldset {
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: 22px;
+		padding: clamp(1rem, 3vw, 1.5rem);
+		background: rgba(2, 6, 23, 0.26);
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	legend {
+		font-weight: 600;
+		padding: 0 0.5rem;
+		color: var(--text-muted);
+	}
+
+	.input-hint {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.chipper-editor {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		background: var(--deep-space);
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+		padding: 1.5rem;
+	}
+
+	.chipper-heading h3 {
+		margin: 0;
+		font-size: 1.25rem;
+	}
+
+	.chipper-heading p {
+		margin: 0.25rem 0 0;
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.chipper-grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 120px 180px auto;
+		gap: 0.75rem;
+		align-items: center;
+	}
+
+	.chipper-grid + .chipper-grid {
+		border-top: 1px solid var(--border-color);
+		padding-top: 0.85rem;
+		margin-top: 0.85rem;
+	}
+
+	.chipper-grid-header {
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+		border-bottom: 1px solid var(--border-color);
+		padding-bottom: 0.35rem;
+	}
+
+	.chipper-grid-header span:last-child {
+		justify-self: center;
+	}
+
+	.chipper-movement {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.chipper-index {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 999px;
+		background: var(--surface-1);
+		color: var(--text-muted);
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+
+	.chipper-movement input {
+		flex: 1;
+	}
+
+	.chipper-reps input {
+		text-align: center;
+	}
+
+	.chipper-category select {
+		width: 100%;
+	}
+
+	.chipper-finisher {
+		border-top: 1px solid var(--border-color);
+		padding-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.chipper-finisher h4 {
+		margin: 0;
+		font-size: 1.1rem;
+	}
+
+	.chipper-finisher p {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.finisher-grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(140px, 220px);
+		gap: 1rem;
+	}
+
+	.finisher-grid label {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		display: block;
+		margin-bottom: 0.35rem;
+	}
+
+	.finisher-name input,
+	.finisher-category select,
+	#finisher-notes {
+		width: 100%;
+	}
+
+	.finisher-notes-label {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		border: 0;
+	}
+
+	.exercise-item {
+		display: grid;
+		grid-template-columns: 2fr 1fr 2fr auto;
+		gap: 0.75rem;
+		align-items: center;
+	}
+
+	.station-editor-card {
+		background: rgba(15, 23, 42, 0.78);
+		border-radius: 22px;
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		box-shadow: 0 16px 45px rgba(0, 0, 0, 0.2);
+	}
+
+	.station-editor-header {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.station-name-input {
+		flex: 1;
+		font-size: 1.1rem;
+		font-weight: 600;
+		border: none;
+		border-bottom: 2px solid var(--border-color);
+		background: transparent;
+		color: var(--text-primary);
+		padding-bottom: 0.35rem;
+	}
+
+	.partner-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 1.25rem;
+	}
+
+	.partner-column {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.starter-select {
+		border-top: 1px solid var(--border-color);
+		padding-top: 1rem;
+	}
+
+	.starter-label {
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--text-muted);
+		margin-bottom: 0.5rem;
+	}
+
+	.radio-group {
+		display: flex;
+		gap: 1.5rem;
+	}
+
+	.remove-btn {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1.5rem;
+		cursor: pointer;
+		padding: 0 0.35rem;
+	}
+
+	.remove-btn:hover {
+		color: var(--brand-yellow);
+	}
+
+	.exercise-actions {
+		display: flex;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.secondary-btn,
+	.primary-btn {
+		border: none;
+		border-radius: 999px;
+		padding: 0.85rem 1.5rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.secondary-btn {
+		background: transparent;
+		border: 1px solid var(--border-color);
+		color: var(--text-primary);
+	}
+
+	.secondary-btn:hover {
+		border-color: var(--brand-yellow);
+		color: var(--brand-yellow);
+	}
+
+	.primary-btn {
+		background: linear-gradient(135deg, var(--brand-green), #86efac);
+		color: #052e16;
+		box-shadow: 0 18px 36px -22px rgba(34, 197, 94, 0.9);
+	}
+
+	.library-btn {
+		background: linear-gradient(135deg, var(--brand-yellow), #fde68a);
+		color: #422006;
+	}
+
+	.submit-btn {
+		align-self: flex-end;
+		padding: 1rem 2.5rem;
+		font-size: 1.1rem;
+	}
+
+	.primary-btn:disabled {
+		opacity: 0.65;
+		cursor: not-allowed;
+	}
+
+	.success-message {
+		color: var(--brand-green);
+		font-weight: 600;
+	}
+
+	.error-message {
+		color: #f87171;
+		font-weight: 600;
+	}
+
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(5, 8, 15, 0.78);
+		backdrop-filter: blur(4px);
+		padding: clamp(1.5rem, 4vw, 3rem);
+		z-index: 10;
+	}
+
+	@media (max-width: 720px) {
+		.chipper-grid {
+			grid-template-columns: 1fr;
+			gap: 0.5rem;
+		}
+
+		.chipper-grid-header {
+			display: none;
+		}
+
+		.chipper-movement {
+			justify-content: flex-start;
+		}
+
+		.chipper-index {
+			width: 28px;
+			height: 28px;
+			font-size: 0.8rem;
+		}
+
+		.remove-btn {
+			justify-self: flex-start;
+			padding-left: 0;
+		}
+
+		.finisher-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.modal-content {
+		width: min(720px, 100%);
+		background: var(--surface-1);
+		border-radius: 18px;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		padding: clamp(1.5rem, 4vw, 2.25rem);
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		position: relative;
+		box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+		max-height: min(720px, calc(100vh - 4rem));
+		overflow: hidden;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1.75rem;
+		cursor: pointer;
+	}
+
+	.close-btn:hover {
+		color: var(--brand-yellow);
+	}
+
+	.library-toolbar {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		align-items: stretch;
+	}
+
+	.search-bar {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem 1rem;
+		border-radius: 999px;
+		border: 1px solid var(--border-color);
+		background: rgba(17, 23, 34, 0.85);
+		transition:
+			border-color 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	.search-bar:focus-within {
+		border-color: var(--brand-yellow);
+		box-shadow: 0 0 0 3px rgba(247, 224, 120, 0.18);
+	}
+
+	.search-bar input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		color: var(--text-primary);
+		font-size: 0.95rem;
+		outline: none;
+	}
+
+	.search-bar input::placeholder {
+		color: var(--text-muted);
+	}
+
+	.search-icon {
+		width: 1.1rem;
+		height: 1.1rem;
+		color: var(--text-muted);
+		flex-shrink: 0;
+	}
+
+	.clear-search {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		padding: 0.25rem;
+		border-radius: 999px;
+		cursor: pointer;
+		transition:
+			color 0.2s ease,
+			background 0.2s ease;
+	}
+
+	.clear-search:hover,
+	.clear-search:focus-visible {
+		color: var(--brand-yellow);
+		background: rgba(247, 224, 120, 0.08);
+	}
+
+	.clear-search:focus-visible {
+		outline: 2px solid var(--brand-yellow);
+		outline-offset: 2px;
+	}
+
+	.result-count {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	@media (min-width: 560px) {
+		.library-toolbar {
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		.result-count {
+			text-align: right;
+		}
+	}
+
+	.library-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 1rem;
+		max-height: clamp(320px, 55vh, 540px);
+		overflow-y: auto;
+		padding-right: 0.25rem;
+	}
+
+	.library-grid::-webkit-scrollbar {
+		width: 0.4rem;
+	}
+
+	.library-grid::-webkit-scrollbar-thumb {
+		background: rgba(255, 255, 255, 0.12);
+		border-radius: 999px;
+	}
+
+	.library-item {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
+		border-radius: 12px;
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		background: linear-gradient(145deg, rgba(17, 24, 39, 0.92), rgba(17, 24, 39, 0.78));
+		color: var(--text-primary);
+		padding: 1rem;
+		cursor: pointer;
+		text-align: left;
+		transition:
+			border-color 0.2s ease,
+			transform 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	.library-item.selected {
+		border-color: rgba(247, 224, 120, 0.6);
+		box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+	}
+
+	.library-item:hover {
+		border-color: rgba(247, 224, 120, 0.6);
+		transform: translateY(-2px);
+		box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+	}
+
+	.library-item:focus-visible {
+		outline: 2px solid var(--brand-yellow);
+		outline-offset: 3px;
+	}
+
+	.library-item-header {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+	}
+
+	.library-item-checkbox {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.5rem;
+		height: 1.5rem;
+		border-radius: 8px;
+		border: 1.5px solid rgba(255, 255, 255, 0.16);
+		background: rgba(17, 24, 39, 0.75);
+		color: var(--brand-yellow);
+		transition:
+			border-color 0.2s ease,
+			background 0.2s ease;
+	}
+
+	.library-item.selected .library-item-checkbox {
+		border-color: rgba(247, 224, 120, 0.9);
+		background: rgba(247, 224, 120, 0.15);
+	}
+
+	.library-item-checkbox svg {
+		width: 1rem;
+		height: 1rem;
+	}
+
+	.library-item-name {
+		font-weight: 600;
+	}
+
+	.library-item-category {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	.library-item-equipment {
+		font-size: 0.75rem;
+		color: var(--text-secondary);
+	}
+
+	.library-footer {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		margin-top: 1.25rem;
+	}
+
+	.selection-count {
+		font-size: 0.9rem;
+		color: var(--text-muted);
+	}
+
+	.import-btn {
+		align-self: flex-start;
+		padding-inline: 1.75rem;
+	}
+
+	.import-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.empty-state {
+		text-align: center;
+		color: var(--text-muted);
+	}
+
+	@media (max-width: 680px) {
+		.exercise-item {
+			grid-template-columns: 1fr;
+		}
+
+		.exercise-actions {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.submit-btn {
+			width: 100%;
+			align-self: stretch;
+		}
+	}
+
+	@media (min-width: 560px) {
+		.library-footer {
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		.import-btn {
+			align-self: unset;
+		}
+	}
 </style>

--- a/workout-app/src/routes/admin/sessions/+page.svelte
+++ b/workout-app/src/routes/admin/sessions/+page.svelte
@@ -1,245 +1,258 @@
 <script>
-// @ts-nocheck
-import { onMount } from 'svelte';
-import { get } from 'svelte/store';
-import { db } from '$lib/firebase';
-import {
-  collection,
-  getDocs,
-  addDoc,
-  serverTimestamp,
-  query,
-  orderBy,
-  where,
-  doc,
-  deleteDoc,
-  onSnapshot
-} from 'firebase/firestore';
-import { loading, user } from '$lib/store';
+	// @ts-nocheck
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { db } from '$lib/firebase';
+	import {
+		collection,
+		getDocs,
+		addDoc,
+		serverTimestamp,
+		query,
+		orderBy,
+		where,
+		doc,
+		deleteDoc,
+		onSnapshot
+	} from 'firebase/firestore';
+	import { loading, user } from '$lib/store';
 
-let allWorkouts = [];
-let upcomingSessions = [];
-let pastSessions = [];
-let newSession = { date: '', workoutId: '' };
-let isLoading = true;
-let isSubmitting = false;
-let searchTerm = '';
-let unsubscribeSessions = () => {};
-let currentUid = null;
+	let allWorkouts = [];
+	let upcomingSessions = [];
+	let pastSessions = [];
+	let newSession = { date: '', workoutId: '' };
+	let isLoading = true;
+	let isSubmitting = false;
+	let searchTerm = '';
+	let unsubscribeSessions = () => {};
+	let currentUid = null;
 
-function formatDate(date) {
-if (!date) return null;
-if (date.seconds) {
-return new Date(date.seconds * 1000);
-}
-const d = new Date(date);
-return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-}
+	function formatDate(date) {
+		if (!date) return null;
+		if (date.seconds) {
+			return new Date(date.seconds * 1000);
+		}
+		const d = new Date(date);
+		return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+	}
 
-async function fetchAttendanceForSessions(sessionIds, creatorId) {
-  const attendanceMap = new Map();
+	async function fetchAttendanceForSessions(sessionIds, creatorId) {
+		const attendanceMap = new Map();
 
-  if (!sessionIds.length) {
-    return attendanceMap;
-  }
+		if (!sessionIds.length) {
+			return attendanceMap;
+		}
 
-  try {
-    const attendanceSnapshots = await Promise.all(
-      sessionIds.map((id) =>
-        getDocs(
-          query(
-            collection(db, 'attendance'),
-            ...(creatorId ? [where('creatorId', '==', creatorId)] : []),
-            where('sessionId', '==', id)
-          )
-        )
-      )
-    );
+		try {
+			const attendanceSnapshots = await Promise.all(
+				sessionIds.map((id) =>
+					getDocs(
+						query(
+							collection(db, 'attendance'),
+							...(creatorId ? [where('creatorId', '==', creatorId)] : []),
+							where('sessionId', '==', id)
+						)
+					)
+				)
+			);
 
-    attendanceSnapshots.forEach((snapshot, index) => {
-      const sessionId = sessionIds[index];
-      attendanceMap.set(
-        sessionId,
-        snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
-      );
-    });
-  } catch (error) {
-    console.error('Failed to fetch attendance records for sessions', error);
-  }
+			attendanceSnapshots.forEach((snapshot, index) => {
+				const sessionId = sessionIds[index];
+				attendanceMap.set(
+					sessionId,
+					snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
+				);
+			});
+		} catch (error) {
+			console.error('Failed to fetch attendance records for sessions', error);
+		}
 
-  return attendanceMap;
-}
+		return attendanceMap;
+	}
 
-async function watchSessions(uid) {
-  unsubscribeSessions();
+	async function watchSessions(uid) {
+		unsubscribeSessions();
 
-  const workoutsQuery = query(collection(db, 'workouts'), where('creatorId', '==', uid));
-  const workoutsSnapshot = await getDocs(workoutsQuery);
-  allWorkouts = workoutsSnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+		const workoutsQuery = query(collection(db, 'workouts'), where('creatorId', '==', uid));
+		const workoutsSnapshot = await getDocs(workoutsQuery);
+		allWorkouts = workoutsSnapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
 
-  const sessionsQuery = query(
-    collection(db, 'sessions'),
-    where('creatorId', '==', uid),
-    orderBy('sessionDate', 'desc')
-  );
+		const sessionsQuery = query(
+			collection(db, 'sessions'),
+			where('creatorId', '==', uid),
+			orderBy('sessionDate', 'desc')
+		);
 
-  let sessionUpdateToken = 0;
+		let sessionUpdateToken = 0;
 
-  unsubscribeSessions = onSnapshot(
-    sessionsQuery,
-    (snapshot) => {
-      const baseSessions = snapshot.docs.map((docSnap) => {
-        const data = docSnap.data();
-        return {
-          id: docSnap.id,
-          ...data,
-          rsvps: data.rsvps ?? [],
-          attendance: []
-        };
-      });
+		unsubscribeSessions = onSnapshot(
+			sessionsQuery,
+			(snapshot) => {
+				const baseSessions = snapshot.docs.map((docSnap) => {
+					const data = docSnap.data();
+					return {
+						id: docSnap.id,
+						...data,
+						rsvps: data.rsvps ?? [],
+						attendance: []
+					};
+				});
 
-      const sessionIds = baseSessions.map((session) => session.id);
-      const currentToken = ++sessionUpdateToken;
+				const sessionIds = baseSessions.map((session) => session.id);
+				const currentToken = ++sessionUpdateToken;
 
-      void (async () => {
-        const attendanceMap = await fetchAttendanceForSessions(sessionIds, uid);
+				void (async () => {
+					const attendanceMap = await fetchAttendanceForSessions(sessionIds, uid);
 
-        if (currentToken !== sessionUpdateToken) {
-          return;
-        }
+					if (currentToken !== sessionUpdateToken) {
+						return;
+					}
 
-        const enrichedSessions = baseSessions.map((session) => ({
-          ...session,
-          attendance: attendanceMap.get(session.id) ?? []
-        }));
+					const enrichedSessions = baseSessions.map((session) => ({
+						...session,
+						attendance: attendanceMap.get(session.id) ?? []
+					}));
 
-        const startOfToday = new Date();
-        startOfToday.setHours(0, 0, 0, 0);
+					const startOfToday = new Date();
+					startOfToday.setHours(0, 0, 0, 0);
 
-        upcomingSessions = enrichedSessions
-          .filter((session) => {
-            const date = formatDate(session.sessionDate);
-            return date && date >= startOfToday;
-          })
-          .reverse();
+					upcomingSessions = enrichedSessions
+						.filter((session) => {
+							const date = formatDate(session.sessionDate);
+							return date && date >= startOfToday;
+						})
+						.reverse();
 
-        pastSessions = enrichedSessions.filter((session) => {
-          const date = formatDate(session.sessionDate);
-          return date && date < startOfToday;
-        });
+					pastSessions = enrichedSessions.filter((session) => {
+						const date = formatDate(session.sessionDate);
+						return date && date < startOfToday;
+					});
 
-        isLoading = false;
-      })();
-    },
-    (error) => {
-      console.error('Failed to subscribe to sessions', error);
-      isLoading = false;
-    }
-  );
-}
+					isLoading = false;
+				})();
+			},
+			(error) => {
+				console.error('Failed to subscribe to sessions', error);
+				isLoading = false;
+			}
+		);
+	}
 
-onMount(() => {
-  const unsubscribeUser = user.subscribe(async ($user) => {
-    const uid = $user?.uid ?? null;
+	onMount(() => {
+		const unsubscribeUser = user.subscribe(async ($user) => {
+			const uid = $user?.uid ?? null;
 
-    if (!uid) {
-      unsubscribeSessions();
-      currentUid = null;
-      allWorkouts = [];
-      upcomingSessions = [];
-      pastSessions = [];
-      isLoading = get(loading);
-      return;
-    }
+			if (!uid) {
+				unsubscribeSessions();
+				currentUid = null;
+				allWorkouts = [];
+				upcomingSessions = [];
+				pastSessions = [];
+				isLoading = get(loading);
+				return;
+			}
 
-    if (uid === currentUid) return;
-    currentUid = uid;
-    isLoading = true;
-    try {
-      await watchSessions(uid);
-    } catch (error) {
-      console.error('Failed to initialise sessions dashboard', error);
-      isLoading = false;
-    }
-  });
+			if (uid === currentUid) return;
+			currentUid = uid;
+			isLoading = true;
+			try {
+				await watchSessions(uid);
+			} catch (error) {
+				console.error('Failed to initialise sessions dashboard', error);
+				isLoading = false;
+			}
+		});
 
-  const unsubscribeLoading = loading.subscribe(($loading) => {
-    if (!get(user)?.uid) {
-      isLoading = $loading;
-    }
-  });
+		const unsubscribeLoading = loading.subscribe(($loading) => {
+			if (!get(user)?.uid) {
+				isLoading = $loading;
+			}
+		});
 
-  unsubscribeSessions = () => {};
+		unsubscribeSessions = () => {};
 
-  return () => {
-    unsubscribeSessions();
-    unsubscribeUser();
-    unsubscribeLoading();
-  };
-});
+		return () => {
+			unsubscribeSessions();
+			unsubscribeUser();
+			unsubscribeLoading();
+		};
+	});
 
-async function createSession() {
-  if (!newSession.date || !newSession.workoutId || isSubmitting) {
-    alert('Please select a date and a workout.');
-    return;
-  }
+	async function createSession() {
+		if (!newSession.date || !newSession.workoutId || isSubmitting) {
+			alert('Please select a date and a workout.');
+			return;
+		}
 
-  const currentUser = get(user);
-  if (!currentUser?.uid) {
-    alert('You need to be signed in to create sessions.');
-    return;
-  }
+		const currentUser = get(user);
+		if (!currentUser?.uid) {
+			alert('You need to be signed in to create sessions.');
+			return;
+		}
 
-  const selectedWorkout = allWorkouts.find((w) => w.id === newSession.workoutId);
-  if (!selectedWorkout) {
-    alert('Please choose a valid workout.');
-    return;
-  }
+		const selectedWorkout = allWorkouts.find((w) => w.id === newSession.workoutId);
+		if (!selectedWorkout) {
+			alert('Please choose a valid workout.');
+			return;
+		}
 
-  isSubmitting = true;
-  try {
-    const sessionData = {
-      creatorId: currentUser.uid,
-      sessionDate: formatDate(newSession.date),
-      workoutId: selectedWorkout.id,
-      workoutTitle: selectedWorkout.title,
-      rsvps: [],
-      attendance: [],
-      createdAt: serverTimestamp()
-    };
-    await addDoc(collection(db, 'sessions'), sessionData);
-    newSession = { date: '', workoutId: '' };
-  } catch (error) {
-    console.error('Error creating session:', error);
-    alert('Failed to create session.');
-  } finally {
-    isSubmitting = false;
-  }
-}
+		isSubmitting = true;
+		try {
+			const sessionData = {
+				creatorId: currentUser.uid,
+				sessionDate: formatDate(newSession.date),
+				workoutId: selectedWorkout.id,
+				workoutTitle: selectedWorkout.title,
+				rsvps: [],
+				attendance: [],
+				createdAt: serverTimestamp()
+			};
+			await addDoc(collection(db, 'sessions'), sessionData);
+			newSession = { date: '', workoutId: '' };
+		} catch (error) {
+			console.error('Error creating session:', error);
+			alert('Failed to create session.');
+		} finally {
+			isSubmitting = false;
+		}
+	}
 
-async function deleteSession(sessionId) {
-if (!confirm('Are you sure you want to delete this session?')) return;
-try {
-await deleteDoc(doc(db, 'sessions', sessionId));
-} catch (error) {
-console.error('Error deleting session:', error);
-alert('Failed to delete session.');
-}
-}
+	async function deleteSession(sessionId) {
+		if (!confirm('Are you sure you want to delete this session?')) return;
+		try {
+			await deleteDoc(doc(db, 'sessions', sessionId));
+		} catch (error) {
+			console.error('Error deleting session:', error);
+			alert('Failed to delete session.');
+		}
+	}
 
-$: filteredPastSessions = pastSessions.filter((s) =>
-s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
-);
+	$: filteredPastSessions = pastSessions.filter((s) =>
+		s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
+	);
 </script>
 
 <div class="page-container">
 	<header class="page-header">
-		<h1>Manage Sessions</h1>
-		<p>Create new class events and view upcoming and past sessions.</p>
+		<div>
+			<p class="eyebrow">Coach planner</p>
+			<h1>Manage Sessions</h1>
+			<p>Create class events, launch the live timer and review results from one clean workspace.</p>
+		</div>
+		<div class="session-stats" aria-label="Session overview">
+			<span><strong>{upcomingSessions.length}</strong> upcoming</span>
+			<span><strong>{pastSessions.length}</strong> completed</span>
+		</div>
 	</header>
 
 	<section class="card create-session-card">
-		<h2>Create New Session</h2>
+		<div class="create-card-heading">
+			<div>
+				<p class="eyebrow">Quick schedule</p>
+				<h2>Create New Session</h2>
+			</div>
+			<p>Pick the class date and attach the workout your clients should see.</p>
+		</div>
 		<form on:submit|preventDefault={createSession} class="create-form">
 			<div class="form-group">
 				<label for="sessionDate">Session Date</label>
@@ -280,18 +293,15 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 							</div>
 							<button class="delete-btn" on:click={() => deleteSession(session.id)}>&times;</button>
 						</div>
-                                                        <div class="session-details">
-                                                        <h3>{session.workoutTitle}</h3>
-                                                        <p>{session.rsvps?.length ?? 0} Attendees Booked</p>
-                                                </div>
-                                                <div class="card-actions">
-                                                        <a
-                                                                href={`/timer/${session.workoutId}?session_id=${session.id}`}
-                                                                class="start-btn"
-                                                        >
-                                                                Start Session
-                                                        </a>
-                                                </div>
+						<div class="session-details">
+							<h3>{session.workoutTitle}</h3>
+							<p>{session.rsvps?.length ?? 0} Attendees Booked</p>
+						</div>
+						<div class="card-actions">
+							<a href={`/timer/${session.workoutId}?session_id=${session.id}`} class="start-btn">
+								Start Session
+							</a>
+						</div>
 					</div>
 				{/each}
 			</div>
@@ -311,21 +321,21 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 			<div class="sessions-grid">
 				{#each filteredPastSessions as session}
 					{@const displayDate = formatDate(session.sessionDate)}
-                                        <div class="session-card past">
-                                                <div class="session-header">
-                                                        <div class="session-date">
-                                                                {#if displayDate}
-                                                                        <span>{displayDate.toLocaleDateString('en-GB')}</span>
-                                                                {/if}
-                                                        </div>
-                                                        <button class="delete-btn" on:click={() => deleteSession(session.id)}>&times;</button>
-                                                </div>
-                                                <div class="session-details">
-                                                        <h3>{session.workoutTitle}</h3>
-                                                        <p class:empty={!session.attendance?.length}>
-                                                                {session.attendance?.length ?? 0} Attended
-                                                        </p>
-                                                </div>
+					<div class="session-card past">
+						<div class="session-header">
+							<div class="session-date">
+								{#if displayDate}
+									<span>{displayDate.toLocaleDateString('en-GB')}</span>
+								{/if}
+							</div>
+							<button class="delete-btn" on:click={() => deleteSession(session.id)}>&times;</button>
+						</div>
+						<div class="session-details">
+							<h3>{session.workoutTitle}</h3>
+							<p class:empty={!session.attendance?.length}>
+								{session.attendance?.length ?? 0} Attended
+							</p>
+						</div>
 						<div class="card-actions">
 							<a href={`/admin/results/${session.id}`} class="secondary-btn">View Results</a>
 						</div>
@@ -338,57 +348,140 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 
 <style>
 	.page-container {
-		max-width: 1400px;
-		margin: 2rem auto;
+		width: min(1400px, 100%);
+		margin: 0 auto;
+		padding: clamp(0.5rem, 2vw, 1rem) 0 2rem;
+	}
+
+	.page-header {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 1rem;
+		align-items: end;
+		margin-bottom: 1rem;
+		padding: clamp(1.4rem, 4vw, 2.3rem);
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: var(--radius-xl);
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.6));
+		box-shadow: var(--shadow-card);
+	}
+
+	.eyebrow {
+		color: var(--brand-yellow);
+		font-size: 0.76rem;
+		font-weight: 900;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+	}
+
+	.page-header h1 {
+		font-family: var(--font-display);
+		font-size: clamp(3rem, 7vw, 5.5rem);
+		line-height: 0.9;
+	}
+
+	.page-header p:last-child,
+	.create-card-heading p {
+		color: var(--text-secondary);
+	}
+
+	.session-stats {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(120px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.session-stats span {
+		display: grid;
+		gap: 0.2rem;
+		padding: 0.9rem 1rem;
+		border: 1px solid var(--border-color);
+		border-radius: 18px;
+		background: rgba(2, 6, 23, 0.36);
+		color: var(--text-muted);
+	}
+
+	.session-stats strong {
+		color: var(--text-primary);
+		font-size: 1.8rem;
+		line-height: 1;
 	}
 
 	.card {
-		background: var(--surface-1);
-		border: 1px solid var(--border-color);
-		border-radius: 16px;
-		padding: 2rem;
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(30, 41, 59, 0.58));
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: var(--radius-xl);
+		padding: clamp(1.2rem, 3vw, 2rem);
+		box-shadow: var(--shadow-card);
+	}
+
+	.create-card-heading {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1.2rem;
+	}
+
+	.create-card-heading h2,
+	.sessions-list h2 {
+		font-family: var(--font-display);
+		font-size: clamp(2rem, 4vw, 3rem);
+		line-height: 0.95;
 	}
 
 	.create-form {
 		display: grid;
-		grid-template-columns: 1fr 1fr auto;
+		grid-template-columns: minmax(180px, 0.8fr) minmax(260px, 1.2fr) auto;
 		gap: 1rem;
 		align-items: flex-end;
 	}
 
 	.primary-btn {
 		border: none;
-		background: var(--brand-green);
-		color: var(--text-primary);
-		padding: 0.75rem 2rem;
-		border-radius: 12px;
-		font-weight: 600;
+		background: linear-gradient(135deg, var(--brand-green), #86efac);
+		color: #052e16;
+		padding: 0.88rem 2rem;
+		border-radius: 16px;
+		font-weight: 900;
 		cursor: pointer;
 		height: fit-content;
+		box-shadow: 0 18px 36px -22px rgba(34, 197, 94, 0.9);
 	}
 
 	.sessions-list {
-		margin-top: 3rem;
+		margin-top: 2rem;
 	}
 
 	.sessions-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
-		gap: 1.5rem;
-		margin-top: 1.5rem;
+		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+		gap: 1rem;
+		margin-top: 1rem;
 	}
 
 	.session-card {
-		background: var(--surface-2);
-		border-radius: 12px;
-		padding: 1.5rem;
+		position: relative;
+		overflow: hidden;
+		background: rgba(15, 23, 42, 0.72);
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: 22px;
+		padding: 1.3rem;
 		display: flex;
 		flex-direction: column;
+		box-shadow: 0 18px 50px rgba(0, 0, 0, 0.2);
+	}
+
+	.session-card::before {
+		position: absolute;
+		inset: 0 auto 0 0;
+		width: 5px;
+		background: linear-gradient(var(--brand-yellow), var(--brand-green));
+		content: '';
 	}
 
 	.session-card.past {
-		background: var(--surface-1);
-		opacity: 0.7;
+		background: rgba(15, 23, 42, 0.54);
+		opacity: 0.86;
 	}
 
 	.session-header {
@@ -400,18 +493,21 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 	}
 
 	.session-date {
+		display: grid;
+		gap: 0.15rem;
 		font-family: var(--font-display);
 		font-size: 1.5rem;
+		line-height: 1;
 		color: var(--brand-yellow);
 	}
 
-        .session-details {
-                flex-grow: 1;
-        }
+	.session-details {
+		flex-grow: 1;
+	}
 
-        .session-details p.empty {
-                color: var(--text-muted);
-        }
+	.session-details p.empty {
+		color: var(--text-muted);
+	}
 
 	.session-details h3 {
 		font-size: 1.25rem;
@@ -444,8 +540,8 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 	}
 
 	.start-btn {
-		background: var(--brand-green);
-		color: var(--text-primary);
+		background: linear-gradient(135deg, var(--brand-yellow), var(--brand-green));
+		color: #07111f;
 	}
 
 	.secondary-btn {
@@ -462,10 +558,21 @@ s.workoutTitle.toLowerCase().includes(searchTerm.toLowerCase())
 	}
 
 	.list-header input {
-		padding: 0.5rem 1rem;
+		padding: 0.7rem 1rem;
 		border-radius: 999px;
 		border: 1px solid var(--border-color);
-		background: var(--deep-space);
+		background: rgba(2, 6, 23, 0.58);
 		color: var(--text-primary);
+	}
+
+	@media (max-width: 860px) {
+		.page-header,
+		.create-form {
+			grid-template-columns: 1fr;
+		}
+
+		.create-card-heading {
+			flex-direction: column;
+		}
 	}
 </style>

--- a/workout-app/src/routes/dashboard/+page.svelte
+++ b/workout-app/src/routes/dashboard/+page.svelte
@@ -244,12 +244,21 @@
 				Your next class, recent benchmarks and coach actions are now in one cleaner place.
 			</p>
 		</div>
-		{#if $isAdmin}
-			<div class="hero-actions" aria-label="Coach shortcuts">
-				<a href={resolve('/admin/create')} class="quick-action primary">Create workout</a>
-				<a href={resolve('/admin/sessions')} class="quick-action">Schedule class</a>
-			</div>
-		{/if}
+		<div class="hero-panel">
+			<span class="hero-panel-label">Next class</span>
+			<strong>{upcomingSession ? nextSessionDateLabel : 'No session'}</strong>
+			<span
+				>{upcomingSession
+					? `${nextSessionTimeLabel || 'Time TBC'} · ${nextSessionCount} booked`
+					: 'Create a class to get started'}</span
+			>
+			{#if $isAdmin}
+				<div class="hero-actions" aria-label="Coach shortcuts">
+					<a href={resolve('/admin/create')} class="quick-action primary">Create workout</a>
+					<a href={resolve('/admin/sessions')} class="quick-action">Schedule class</a>
+				</div>
+			{/if}
+		</div>
 	</header>
 
 	{#if isLoading}
@@ -420,19 +429,37 @@
 	.dashboard-hero,
 	.dashboard-section,
 	.metric-card {
-		border: 1px solid var(--border-color);
-		background: rgba(15, 23, 42, 0.68);
-		box-shadow: var(--shadow-card);
-		backdrop-filter: blur(18px);
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(30, 41, 59, 0.58));
+		box-shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+		backdrop-filter: blur(20px);
 	}
 
 	.dashboard-hero {
-		display: flex;
-		align-items: flex-end;
-		justify-content: space-between;
-		gap: 1.5rem;
-		padding: clamp(1.4rem, 4vw, 2.4rem);
+		position: relative;
+		overflow: hidden;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(280px, 390px);
+		align-items: stretch;
+		gap: clamp(1rem, 3vw, 2rem);
+		padding: clamp(1.4rem, 4vw, 2.6rem);
 		border-radius: var(--radius-xl);
+	}
+
+	.dashboard-hero::before {
+		position: absolute;
+		inset: -20% auto auto 45%;
+		width: 34rem;
+		height: 34rem;
+		border-radius: 999px;
+		background: radial-gradient(circle, rgba(250, 204, 21, 0.18), transparent 62%);
+		content: '';
+		pointer-events: none;
+	}
+
+	.dashboard-hero > * {
+		position: relative;
+		z-index: 1;
 	}
 
 	.eyebrow {
@@ -461,6 +488,33 @@
 		margin-top: 0.9rem;
 		color: var(--text-secondary);
 		font-size: clamp(1rem, 2vw, 1.15rem);
+	}
+
+	.hero-panel {
+		display: grid;
+		align-content: center;
+		gap: 0.55rem;
+		padding: 1.2rem;
+		border: 1px solid rgba(250, 204, 21, 0.18);
+		border-radius: 24px;
+		background: rgba(2, 6, 23, 0.38);
+	}
+
+	.hero-panel-label {
+		color: var(--brand-yellow);
+		font-size: 0.75rem;
+		font-weight: 900;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+	}
+
+	.hero-panel strong {
+		font-size: clamp(1.3rem, 3vw, 2rem);
+		line-height: 1.05;
+	}
+
+	.hero-panel span:last-of-type {
+		color: var(--text-secondary);
 	}
 
 	.hero-actions,
@@ -507,10 +561,23 @@
 	}
 
 	.metric-card {
+		position: relative;
+		overflow: hidden;
 		display: grid;
 		gap: 0.35rem;
 		padding: 1.25rem;
 		border-radius: var(--radius-lg);
+	}
+
+	.metric-card::after {
+		position: absolute;
+		right: -2.5rem;
+		top: -2.5rem;
+		width: 8rem;
+		height: 8rem;
+		border-radius: 999px;
+		background: rgba(56, 189, 248, 0.1);
+		content: '';
 	}
 
 	.metric-card strong {
@@ -586,9 +653,9 @@
 		justify-content: space-between;
 		gap: 1.25rem;
 		padding: clamp(1rem, 3vw, 1.4rem);
-		border: 1px solid var(--border-color);
-		border-radius: var(--radius-lg);
-		background: rgba(255, 255, 255, 0.07);
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: 24px;
+		background: rgba(2, 6, 23, 0.35);
 	}
 
 	.session-card.today {
@@ -628,9 +695,9 @@
 		gap: 0.45rem;
 		min-height: 150px;
 		padding: 1rem;
-		border: 1px solid var(--border-color);
+		border: 1px solid rgba(226, 232, 240, 0.14);
 		border-radius: var(--radius-lg);
-		background: rgba(255, 255, 255, 0.07);
+		background: rgba(2, 6, 23, 0.35);
 		text-decoration: none;
 		transition:
 			transform var(--transition),

--- a/workout-app/src/routes/live/[sessionId]/+page.svelte
+++ b/workout-app/src/routes/live/[sessionId]/+page.svelte
@@ -1,3481 +1,3757 @@
 <script>
-// @ts-nocheck
-import { onMount } from 'svelte';
-import { db } from '$lib/firebase';
-import { normaliseStationAssignments, serialiseStationAssignments } from '$lib/stationAssignments';
-import { buildChipperGroups } from '$lib/chipper';
-import {
-        doc,
-        onSnapshot,
-        addDoc,
-        serverTimestamp,
-        collection,
-        setDoc,
-        runTransaction,
-        deleteDoc,
-        updateDoc,
-        arrayUnion
-} from 'firebase/firestore';
-import { user } from '$lib/store';
-
-export let data;
-const { session, workout } = data;
-const isChipperMode = workout.mode === 'Chipper';
-
-let chipperGroups = [];
-let chipperFinisher = null;
-let chipperSteps = [];
-
-let liveState = { phase: 'Connecting...', remaining: 0, currentStation: 0, isComplete: false, movesCompleted: 0 };
-
-let userProfile = {};
-let myCurrentStationIndex = -1;
-let myNextStationIndex = -1;
-let previousStationIndex = -1;
-
-let hasSavedFinalScore = false;
-let hasJoinedRoster = false;
-let wantsPartnerPairing = workout.mode !== 'Partner';
-let pairingLocked = workout.mode !== 'Partner';
-let isTrainingSolo = false;
-
-let myPartnerSlot = -1;
-let myPartnerRole = '';
-let myActiveTaskLabel = '';
-let currentP1Task = '';
-let currentP2Task = '';
-let soloPrimaryTask = '';
-let soloSecondaryTask = '';
-const DEFAULT_CATEGORY = 'Bodyweight';
-let stationCategory = DEFAULT_CATEGORY;
-let primaryTaskDetails = { name: '', category: DEFAULT_CATEGORY };
-let secondaryTaskDetails = { name: '', category: DEFAULT_CATEGORY };
-let activeTask = { name: '', category: DEFAULT_CATEGORY };
-let upcomingTask = null;
-let metricCategory = DEFAULT_CATEGORY;
-let equipmentOptions = [];
-let selectedEquipment = '';
-let equipmentHistory = [];
-let isRestPhase = false;
-let hasSessionStarted = false;
-let showPairingControls = workout.mode === 'Partner';
-let nextStationCategory = '';
-
-let rosterStatus = 'idle';
-let rosterError = '';
-let partnerStatusText = '';
-
-let myScoreRef = null;
-let unsubscribe = [];
-
-const createEntryScore = () => ({ reps: '', weight: '', cals: '', dist: '', notes: '', selection: '' });
-const createCumulativeScore = () => ({ reps: 0, weight: 0, cals: 0, dist: '', notes: '', selections: [] });
-
-function normaliseCategory(category, fallback = '') {
-        const raw = String(category ?? '').trim();
-        if (!raw) return fallback;
-        const lower = raw.toLowerCase();
-        if (lower.includes('cardio')) return 'Cardio Machine';
-        if (lower.includes('resist') || lower.includes('strength') || lower.includes('weight')) return 'Resistance';
-        if (lower.includes('body')) return 'Bodyweight';
-        return raw;
-}
-
-function getMetricLabelForCategory(category) {
-        switch (category) {
-                case 'Resistance':
-                        return 'Reps & Weight';
-                case 'Cardio Machine':
-                        return 'Calories & Distance';
-                case 'Bodyweight':
-                        return 'Reps';
-                default:
-                        return category || '';
-        }
-}
-
-function formatDistance(value) {
-        if (!value) return '';
-        const trimmed = String(value).trim();
-        if (!trimmed) return '';
-        const lower = trimmed.toLowerCase();
-        if (lower.endsWith('m') || lower.endsWith('km')) {
-                return trimmed;
-        }
-        if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
-                return `${trimmed}m`;
-        }
-        return trimmed;
-}
-
-function getFinisherMetricForCategory(category) {
-        const normalised = normaliseCategory(category, '');
-        if (normalised === 'Cardio Machine') {
-                return { key: 'cals', label: 'Calories', placeholder: 'e.g. 80' };
-        }
-        if (normalised === 'Bodyweight' || normalised === 'Resistance') {
-                return { key: 'reps', label: 'Reps', placeholder: 'e.g. 45' };
-        }
-        return { key: 'reps', label: 'Score', placeholder: 'Enter result' };
-}
-
-let currentEntries = workout.exercises.map((ex) => ({
-        stationName: ex.name ?? '',
-        category: ex.category ?? '',
-        score: createEntryScore()
-}));
-
-let cumulativeScores = workout.exercises.map((ex) => ({
-        stationName: ex.name ?? '',
-        category: ex.category ?? '',
-        score: createCumulativeScore()
-}));
-
-let pendingStations = new Set();
-let chipperFinisherName = '';
-let chipperFinisherCategory = DEFAULT_CATEGORY;
-let completedChipperSteps = new Set();
-
-const isAmrapType = String(workout?.type ?? '').toLowerCase() === 'amrap';
-const requiresCompletionLog = isChipperMode || isAmrapType;
-
-let showCompletionModal = false;
-let completionError = '';
-let completionForm = {
-        finisherValue: '',
-        completedChipper: false,
-        progressExercise: '',
-        progressReps: '',
-        amrapRounds: '',
-        amrapReps: ''
-};
-let amrapRoundCount = 0;
-let amrapExtraReps = 0;
-let completionSummaryEntry = null;
-let completionFinisherEntry = null;
-let finisherMetric = null;
-
-let lastSavedStationIndex = -1;
-let lastSaveMessage = '';
-let lastSaveType = 'idle';
-
-let finalSaveStatus = 'idle';
-let finalSaveMessage = '';
-let previousCompletionState = false;
-let totalTime = 0;
-
-let showFeedbackModal = false;
-let feedbackRating = 0;
-let feedbackComment = '';
-let uploadWeightSummary = '';
-let uploadCompletionSummary = '';
-
-function formatAmrapSummary(rounds, reps) {
-        const movementName = workout?.exercises?.[0]?.name?.trim();
-        let summaryNote = `Completed ${rounds} round${rounds === 1 ? '' : 's'}`;
-
-        if (reps > 0) {
-                const movementLabel = movementName ? `${movementName}${reps === 1 ? '' : 's'}` : `rep${reps === 1 ? '' : 's'}`;
-                summaryNote += ` + ${reps} ${movementLabel}`;
-        }
-
-        return summaryNote;
-}
-
-function buildWeightSummary() {
-        const weightEntries = cumulativeScores
-                .map((entry, index) => {
-                        const weightValue = Number(entry.score.weight);
-                        if (!Number.isFinite(weightValue) || weightValue <= 0) return null;
-
-                        const stationLabel = entry.stationName?.trim()
-                                ? entry.stationName.trim()
-                                : `Station ${index + 1}`;
-
-                        return `${stationLabel}: ${weightValue} kg`;
-                })
-                .filter(Boolean);
-
-        if (!weightEntries.length) {
-                return 'No weight logged during this session.';
-        }
-
-        return `Weight used – ${weightEntries.join(' • ')}`;
-}
-
-function buildCompletionSummary() {
-        if (completionSummaryEntry?.score?.notes) {
-                return completionSummaryEntry.score.notes;
-        }
-
-        if (isAmrapType && (amrapRoundCount > 0 || amrapExtraReps > 0)) {
-                return formatAmrapSummary(amrapRoundCount, amrapExtraReps);
-        }
-
-        if (isChipperMode && completedChipperSteps.size > 0) {
-                return `Completed ${completedChipperSteps.size} chipper movement${completedChipperSteps.size === 1 ? '' : 's'}.`;
-        }
-
-        return 'Workout log ready to upload.';
-}
-
-function toggleChipperStepCompletion(order) {
-        const next = new Set(completedChipperSteps);
-        if (next.has(order)) {
-                next.delete(order);
-        } else {
-                next.add(order);
-        }
-        completedChipperSteps = next;
-}
-
-function syncAmrapCompletion(roundsValue = amrapRoundCount, extraValue = amrapExtraReps) {
-        const safeRounds = Math.max(0, Math.floor(Number(roundsValue) || 0));
-        const safeReps = Math.max(0, Math.floor(Number(extraValue) || 0));
-
-        amrapRoundCount = safeRounds;
-        amrapExtraReps = safeReps;
-
-        completionForm = {
-                ...completionForm,
-                amrapRounds: String(safeRounds),
-                amrapReps: String(safeReps)
-        };
-
-        if (safeRounds === 0 && safeReps === 0) {
-                completionSummaryEntry = null;
-                return;
-        }
-
-        const summaryNote = formatAmrapSummary(safeRounds, safeReps);
-
-        completionSummaryEntry = {
-                stationName: 'AMRAP Result',
-                category: 'AMRAP',
-                score: { notes: summaryNote }
-        };
-        completionFinisherEntry = null;
-}
-
-function adjustAmrapRounds(delta) {
-        if (!isAmrapType) return;
-        const next = Math.max(0, amrapRoundCount + delta);
-        syncAmrapCompletion(next, amrapExtraReps);
-}
-
-function handleAmrapRepsInput(event) {
-        const value = event?.currentTarget?.value ?? event?.target?.value ?? '0';
-        syncAmrapCompletion(amrapRoundCount, value);
-}
-
-$: if (!isChipperMode && completedChipperSteps.size) {
-        completedChipperSteps = new Set();
-}
-
-$: if (isChipperMode) {
-        const availableOrders = new Set(chipperSteps.map((_, index) => index + 1));
-        const filteredOrders = [...completedChipperSteps].filter((order) => availableOrders.has(order));
-        if (filteredOrders.length !== completedChipperSteps.size) {
-                completedChipperSteps = new Set(filteredOrders);
-        }
-}
-
-onMount(() => {
-        const userUid = $user?.uid;
-        if (!userUid) return;
-
-        myScoreRef = doc(db, 'sessions', session.id, 'attendees', userUid);
-
-        const profileRef = doc(db, 'profiles', userUid);
-        const unsubProfile = onSnapshot(profileRef, (docSnap) => {
-                if (docSnap.exists()) {
-                        userProfile = docSnap.data();
-                }
-        });
-
-        const liveStateRef = doc(db, 'sessions', session.id, 'liveState', 'data');
-        const unsubState = onSnapshot(liveStateRef, (docSnap) => {
-                if (docSnap.exists()) {
-                        liveState = docSnap.data();
-                }
-        });
-
-        const unsubScore = onSnapshot(myScoreRef, (docSnap) => {
-                const didJoin = docSnap.exists();
-                if (didJoin !== hasJoinedRoster) {
-                        hasJoinedRoster = didJoin;
-                }
-                if (workout.mode === 'Partner') {
-                        if (didJoin) {
-                                if (!isTrainingSolo && !pairingLocked) {
-                                        wantsPartnerPairing = true;
-                                }
-                        } else if (!pairingLocked) {
-                                wantsPartnerPairing = false;
-                                isTrainingSolo = false;
-                        }
-                }
-        });
-
-        unsubscribe = [unsubProfile, unsubState, unsubScore];
-
-        return () => unsubscribe.forEach((unsub) => unsub && unsub());
-});
-
-function setEntryScore(index, newScore) {
-        const next = [...currentEntries];
-        next[index] = { ...next[index], score: newScore };
-        currentEntries = next;
-}
-
-function setCumulativeScore(index, newScore) {
-        const next = [...cumulativeScores];
-        next[index] = { ...next[index], score: newScore };
-        cumulativeScores = next;
-}
-
-function resetEntry(index) {
-        setEntryScore(index, createEntryScore());
-}
-
-function hasEntryValue(entry) {
-        if (!entry) return false;
-        return (
-                ['reps', 'weight', 'cals'].some((key) => Number(entry[key]) > 0) ||
-                (entry.dist && entry.dist.trim().length > 0) ||
-                (entry.notes && entry.notes.trim().length > 0) ||
-                (entry.selection && String(entry.selection).trim().length > 0)
-        );
-}
-
-function handleEntryChange(index, field, rawValue) {
-        if (index < 0 || !currentEntries[index]) return;
-
-        const entry = { ...currentEntries[index].score };
-        if (field === 'dist') {
-                entry.dist = rawValue;
-        } else if (field === 'notes') {
-                entry.notes = rawValue;
-        } else {
-                const numeric = Number(rawValue);
-                entry[field] = rawValue === '' ? '' : Math.max(0, Number.isFinite(numeric) ? numeric : 0);
-        }
-
-        setEntryScore(index, entry);
-
-        if (hasEntryValue(entry)) {
-                pendingStations.add(index);
-        } else {
-                pendingStations.delete(index);
-        }
-        pendingStations = new Set(pendingStations);
-
-        if (lastSavedStationIndex === index && !hasEntryValue(entry)) {
-                lastSaveMessage = '';
-                lastSaveType = 'idle';
-        }
-}
-
-function handleSelectionChange(index, option) {
-        if (index < 0 || !currentEntries[index]) return;
-
-        const trimmed = typeof option === 'string' ? option.trim() : '';
-        const entry = { ...currentEntries[index].score, selection: trimmed };
-
-        setEntryScore(index, entry);
-
-        if (hasEntryValue(entry)) {
-                pendingStations.add(index);
-        } else {
-                pendingStations.delete(index);
-        }
-        pendingStations = new Set(pendingStations);
-
-        if (lastSavedStationIndex === index && !hasEntryValue(entry)) {
-                lastSaveMessage = '';
-                lastSaveType = 'idle';
-        }
-}
-
-async function commitStationScore(index, { auto = false } = {}) {
-        if (!hasJoinedRoster || index < 0 || !currentEntries[index]) return;
-
-        const entry = currentEntries[index].score;
-        if (!hasEntryValue(entry)) {
-                pendingStations.delete(index);
-                pendingStations = new Set(pendingStations);
-                resetEntry(index);
-                if (!auto) {
-                        lastSavedStationIndex = index;
-                        lastSaveType = 'info';
-                        lastSaveMessage = 'Add a value before saving.';
-                }
-                return;
-        }
-
-        const cumulative = { ...cumulativeScores[index].score };
-        const selectionHistory = Array.isArray(cumulative.selections) ? [...cumulative.selections] : [];
-        const numericFields = ['reps', 'weight', 'cals'];
-        let hasUpdates = false;
-
-        numericFields.forEach((field) => {
-                const amount = Number(entry[field]);
-                if (Number.isFinite(amount) && amount > 0) {
-                        cumulative[field] = (cumulative[field] || 0) + amount;
-                        hasUpdates = true;
-                }
-        });
-
-        const formattedDistance = formatDistance(entry.dist);
-        if (formattedDistance) {
-                cumulative.dist = cumulative.dist ? `${cumulative.dist} + ${formattedDistance}` : formattedDistance;
-                hasUpdates = true;
-        }
-
-        if (entry.notes && entry.notes.trim()) {
-                const trimmedNotes = entry.notes.trim();
-                cumulative.notes = cumulative.notes ? `${cumulative.notes}\n${trimmedNotes}` : trimmedNotes;
-                hasUpdates = true;
-        }
-
-        if (entry.selection && entry.selection.trim()) {
-                const trimmedSelection = entry.selection.trim();
-                selectionHistory.push(trimmedSelection);
-                cumulative.selections = selectionHistory;
-                hasUpdates = true;
-        } else {
-                cumulative.selections = selectionHistory;
-        }
-
-        if (!hasUpdates) {
-                pendingStations.delete(index);
-                pendingStations = new Set(pendingStations);
-                resetEntry(index);
-                return;
-        }
-
-        setCumulativeScore(index, cumulative);
-        pendingStations.delete(index);
-        pendingStations = new Set(pendingStations);
-        resetEntry(index);
-
-        try {
-                await updateLiveScore(cumulative);
-                lastSavedStationIndex = index;
-                lastSaveType = auto ? 'auto' : 'success';
-                lastSaveMessage = auto
-                        ? 'Saved automatically for your last station.'
-                        : 'Score saved!'
-                ;
-        } catch (error) {
-                console.error('Failed to update live score', error);
-                lastSavedStationIndex = index;
-                lastSaveType = 'error';
-                lastSaveMessage = 'Could not save your score. Please try again.';
-        }
-}
-
-async function updateLiveScore(scoreObject) {
-        if (!hasJoinedRoster || !myScoreRef) return;
-
-        const cleanedScore = {};
-        ['reps', 'weight', 'cals'].forEach((field) => {
-                const value = Number(scoreObject[field]);
-                if (Number.isFinite(value) && value > 0) {
-                        cleanedScore[field] = value;
-                }
-        });
-        const formattedDistance = formatDistance(scoreObject.dist);
-        if (formattedDistance) {
-                cleanedScore.dist = formattedDistance;
-        }
-
-        if (scoreObject.notes && String(scoreObject.notes).trim()) {
-                cleanedScore.notes = String(scoreObject.notes).trim();
-        }
-
-        if (Array.isArray(scoreObject.selections) && scoreObject.selections.length) {
-                cleanedScore.selections = scoreObject.selections;
-        }
-
-        try {
-                await setDoc(
-                        myScoreRef,
-                        {
-                                displayName: userProfile.displayName ?? '',
-                                score: cleanedScore,
-                                currentStation: myCurrentStationIndex >= 0 ? myCurrentStationIndex + 1 : 0,
-                                updatedAt: serverTimestamp()
-                        },
-                        { merge: true }
-                );
-        } catch (error) {
-                console.error('Failed to sync live score', error);
-                throw error;
-        }
-}
-
-async function joinStationRoster({ trainingSolo = false } = {}) {
-        if (rosterStatus === 'joining' || hasJoinedRoster || !$user?.uid || !myScoreRef) return;
-
-        const displayName = (userProfile.displayName || '').trim();
-        const totalStations = workout.exercises?.length ?? 0;
-
-        if (!displayName) {
-                rosterError = 'Add your display name in your profile to join the rotation.';
-                return;
-        }
-        if (!totalStations) {
-                rosterError = 'This workout has no stations configured yet.';
-                return;
-        }
-
-        const uppercaseName = displayName.toUpperCase();
-        const sessionRef = doc(db, 'sessions', session.id);
-
-        rosterStatus = 'joining';
-        rosterError = '';
-
-        try {
-                await runTransaction(db, async (transaction) => {
-                        const snap = await transaction.get(sessionRef);
-                        if (!snap.exists()) return;
-
-                        const data = snap.data();
-                        let assignments = normaliseStationAssignments(data?.stationAssignments, totalStations);
-
-                        if (assignments.length < totalStations) {
-                                assignments = assignments.concat(
-                                        Array.from({ length: totalStations - assignments.length }, () => [])
-                                );
-                        } else if (assignments.length > totalStations) {
-                                assignments = assignments.slice(0, totalStations);
-                        }
-
-                        assignments = assignments.map((codes) => codes.filter((code) => code !== uppercaseName));
-
-                        const counts = assignments.map((codes) => codes.length);
-                        const minCount = counts.length ? Math.min(...counts) : 0;
-                        let targetIndex = counts.findIndex((count) => count === minCount);
-                        if (targetIndex === -1) targetIndex = 0;
-
-                        assignments[targetIndex] = [...(assignments[targetIndex] ?? []), uppercaseName];
-
-                        transaction.set(
-                                sessionRef,
-                                { stationAssignments: serialiseStationAssignments(assignments, totalStations) },
-                                { merge: true }
-                        );
-                });
-
-                await setDoc(
-                        myScoreRef,
-                        { displayName, score: {}, currentStation: 0, joinedAt: serverTimestamp() },
-                        { merge: true }
-                );
-
-                hasJoinedRoster = true;
-                if (workout.mode === 'Partner') {
-                        isTrainingSolo = trainingSolo;
-                        wantsPartnerPairing = !trainingSolo;
-                } else {
-                        wantsPartnerPairing = true;
-                }
-        } catch (error) {
-                console.error('Failed to join station roster', error);
-                rosterError = 'Could not join the rotation. Please try again.';
-        } finally {
-                rosterStatus = 'idle';
-        }
-}
-
-async function leaveStationRoster() {
-        if (rosterStatus === 'leaving' || !$user?.uid || !hasJoinedRoster || !myScoreRef) return;
-
-        const displayName = (userProfile.displayName || '').trim();
-        const uppercaseName = displayName.toUpperCase();
-        const totalStations = workout.exercises?.length ?? 0;
-        const sessionRef = doc(db, 'sessions', session.id);
-
-        rosterStatus = 'leaving';
-        rosterError = '';
-
-        try {
-                if (uppercaseName && totalStations) {
-                        await runTransaction(db, async (transaction) => {
-                                const snap = await transaction.get(sessionRef);
-                                if (!snap.exists()) return;
-
-                                const data = snap.data();
-                                let assignments = normaliseStationAssignments(data?.stationAssignments, totalStations);
-                                assignments = assignments.map((codes) => codes.filter((code) => code !== uppercaseName));
-
-                                transaction.set(
-                                        sessionRef,
-                                        { stationAssignments: serialiseStationAssignments(assignments, totalStations) },
-                                        { merge: true }
-                                );
-                        });
-                }
-
-                await deleteDoc(myScoreRef);
-
-                hasJoinedRoster = false;
-                if (workout.mode === 'Partner') {
-                        if (!pairingLocked) {
-                                wantsPartnerPairing = false;
-                        }
-                        isTrainingSolo = false;
-                        myPartnerSlot = -1;
-                } else {
-                        wantsPartnerPairing = false;
-                }
-                myCurrentStationIndex = -1;
-                myNextStationIndex = -1;
-                previousStationIndex = -1;
-        } catch (error) {
-                console.error('Failed to leave station roster', error);
-                rosterError = 'Could not update the roster. Please try again.';
-        } finally {
-                rosterStatus = 'idle';
-        }
-}
-
-function selectSoloMode() {
-        if (workout.mode !== 'Partner' || pairingLocked || rosterStatus !== 'idle') return;
-
-        isTrainingSolo = true;
-        wantsPartnerPairing = false;
-        pairingLocked = true;
-        rosterError = '';
-
-        if (!hasJoinedRoster) {
-                void joinStationRoster({ trainingSolo: true });
-        }
-}
-
-function selectPartnerMode() {
-        if (workout.mode !== 'Partner' || pairingLocked || rosterStatus !== 'idle') return;
-
-        isTrainingSolo = false;
-        wantsPartnerPairing = true;
-        pairingLocked = true;
-        rosterError = '';
-
-        if (!hasJoinedRoster) {
-                void joinStationRoster({ trainingSolo: false });
-        }
-}
-
-function hasTotals(index) {
-        if (index < 0 || !cumulativeScores[index]) return false;
-        const totals = cumulativeScores[index].score;
-        return (
-                ['reps', 'weight', 'cals'].some((key) => Number(totals[key]) > 0) ||
-                (totals.dist && totals.dist.trim()) ||
-                (totals.notes && totals.notes.trim())
-        );
-}
-
-function hasLoggedScores() {
-        return cumulativeScores.some((item) => {
-                const score = item?.score;
-                if (!score) return false;
-                return (
-                        Number(score.reps) > 0 ||
-                        Number(score.weight) > 0 ||
-                        Number(score.cals) > 0 ||
-                        (score.dist && String(score.dist).trim().length > 0) ||
-                        (score.notes && String(score.notes).trim().length > 0)
-                );
-        });
-}
-
-function hasCompletionEntries() {
-        return Boolean(completionSummaryEntry) || Boolean(completionFinisherEntry);
-}
-
-function completionLogComplete() {
-        if (!requiresCompletionLog) return true;
-        if (isChipperMode) {
-                const needsFinisher = Boolean(finisherMetric);
-                return Boolean(completionSummaryEntry) && (!needsFinisher || Boolean(completionFinisherEntry));
-        }
-        if (isAmrapType) {
-                return Boolean(completionSummaryEntry);
-        }
-        return true;
-}
-
-function openCompletionModal() {
-        completionError = '';
-        if (isChipperMode && !completionForm.progressExercise && chipperSteps.length) {
-                completionForm = { ...completionForm, progressExercise: chipperSteps[0]?.name ?? '' };
-        } else {
-                completionForm = { ...completionForm };
-        }
-        showCompletionModal = true;
-}
-
-function cancelCompletionModal() {
-        completionError = '';
-        showCompletionModal = false;
-}
-
-function proceedToUpload() {
-        if (!hasLoggedScores() && !hasCompletionEntries()) {
-                finalSaveStatus = 'error';
-                finalSaveMessage = 'Log at least one score before uploading your workout.';
-                return;
-        }
-
-        feedbackRating = 0;
-        feedbackComment = '';
-        finalSaveStatus = 'idle';
-        finalSaveMessage = '';
-        uploadWeightSummary = buildWeightSummary();
-        uploadCompletionSummary = buildCompletionSummary();
-        showFeedbackModal = true;
-}
-
-function submitCompletionForm() {
-        completionError = '';
-
-        if (isChipperMode) {
-                const metric = finisherMetric;
-                const metricValue = Number(completionForm.finisherValue);
-                const metricValid = !metric || (Number.isFinite(metricValue) && metricValue > 0);
-                const completedChipper = Boolean(completionForm.completedChipper);
-                const trimmedExercise = String(completionForm.progressExercise || '').trim();
-                const repsValue = Number(completionForm.progressReps);
-                const repsValid = Number.isFinite(repsValue) && repsValue >= 0;
-                const hasChipperSteps = Array.isArray(chipperSteps) && chipperSteps.length > 0;
-
-                if (!metricValid) {
-                        const label = metric?.label?.toLowerCase() ?? 'result';
-                        completionError = `Enter the ${label} you finished with.`;
-                        return;
-                }
-
-                if (!completedChipper && hasChipperSteps) {
-                        if (!trimmedExercise) {
-                                completionError = 'Select the exercise you reached before time capped.';
-                                return;
-                        }
-                        if (!repsValid) {
-                                completionError = 'Enter the reps completed before the clock ran out.';
-                                return;
-                        }
-                }
-
-                const safeMetric = metric ? Math.round(metricValue) : null;
-                const safeReps = Number.isFinite(repsValue) ? Math.max(0, Math.floor(repsValue)) : 0;
-
-                completionForm = {
-                        ...completionForm,
-                        finisherValue: metric && safeMetric !== null ? String(safeMetric) : '',
-                        progressReps: completedChipper ? '' : String(safeReps)
-                };
-
-                if (metric) {
-                        const metricKey = metric.key === 'cals' ? 'cals' : 'reps';
-                        completionFinisherEntry = {
-                                stationName: chipperFinisherName || 'Chipper Finisher',
-                                category: chipperFinisherCategory,
-                                score: { [metricKey]: safeMetric ?? 0 }
-                        };
-                } else {
-                        completionFinisherEntry = null;
-                }
-
-                let summaryNote = 'Completed the entire chipper before the time cap.';
-                if (!completedChipper) {
-                        summaryNote = hasChipperSteps && trimmedExercise
-                                ? `Time capped on ${trimmedExercise} at ${safeReps} rep${safeReps === 1 ? '' : 's'}.`
-                                : `Time capped with ${safeReps} rep${safeReps === 1 ? '' : 's'} remaining.`;
-                }
-
-                completionSummaryEntry = {
-                        stationName: 'Chipper Progress',
-                        category: 'Chipper',
-                        score: { notes: summaryNote }
-                };
-        } else if (isAmrapType) {
-                const roundsValue = Number(completionForm.amrapRounds);
-                const extraValue = Number(completionForm.amrapReps);
-                const hasRounds = Number.isFinite(roundsValue) && roundsValue >= 0;
-                const hasExtra = Number.isFinite(extraValue) && extraValue >= 0;
-
-                if (!hasRounds || !hasExtra) {
-                        completionError = 'Enter the rounds and remaining reps to finish.';
-                        return;
-                }
-
-                const safeRounds = Math.max(0, Math.floor(roundsValue));
-                const safeReps = Math.max(0, Math.floor(extraValue));
-
-                if (safeRounds === 0 && safeReps === 0) {
-                        completionError = 'Log at least one round or rep to complete the AMRAP.';
-                        return;
-                }
-
-                completionForm = {
-                        ...completionForm,
-                        amrapRounds: String(safeRounds),
-                        amrapReps: String(safeReps)
-                };
-
-                syncAmrapCompletion(safeRounds, safeReps);
-
-                const summaryNote = formatAmrapSummary(safeRounds, safeReps);
-
-                completionSummaryEntry = {
-                        stationName: 'AMRAP Result',
-                        category: 'AMRAP',
-                        score: { notes: summaryNote }
-                };
-                completionFinisherEntry = null;
-        }
-
-        showCompletionModal = false;
-        proceedToUpload();
-}
-
-function startUpload() {
-        if (finalSaveStatus === 'saving' || hasSavedFinalScore) return;
-
-        if (!completionLogComplete()) {
-                openCompletionModal();
-                return;
-        }
-
-        proceedToUpload();
-}
-
-function handleFeedbackSubmit(includeFeedback) {
-        if (!includeFeedback) {
-                feedbackRating = 0;
-                feedbackComment = '';
-        }
-        showFeedbackModal = false;
-        void saveFinalScores();
-}
-
-function cancelFeedback() {
-        showFeedbackModal = false;
-}
-
-async function saveFinalScores() {
-        if (hasSavedFinalScore || !$user?.uid) return;
-
-        if (!completionLogComplete()) {
-                finalSaveStatus = 'error';
-                finalSaveMessage = 'Finish logging your workout before uploading.';
-                return;
-        }
-
-        showFeedbackModal = false;
-        finalSaveStatus = 'saving';
-        finalSaveMessage = '';
-
-        const displayName = (userProfile.displayName ?? '').trim();
-        const resolvedDisplayName = displayName || userProfile.email || 'Member';
-
-        const cleanedScores = cumulativeScores
-                .map((item) => {
-                        const cleaned = {};
-                        if (Number(item.score.reps) > 0) cleaned.reps = Number(item.score.reps);
-                        if (Number(item.score.weight) > 0) cleaned.weight = Number(item.score.weight);
-                        if (Number(item.score.cals) > 0) cleaned.cals = Number(item.score.cals);
-                        const formattedDistance = formatDistance(item.score.dist);
-                        if (formattedDistance) cleaned.dist = formattedDistance;
-                        if (item.score.notes && String(item.score.notes).trim()) {
-                                cleaned.notes = String(item.score.notes).trim();
-                        }
-                        if (Array.isArray(item.score.selections) && item.score.selections.length) {
-                                cleaned.selections = item.score.selections;
-                        }
-
-                        if (!Object.keys(cleaned).length) {
-                                return null;
-                        }
-
-                        const stationName =
-                                typeof item.stationName === 'string' && item.stationName.trim()
-                                        ? item.stationName.trim()
-                                        : null;
-                        const category =
-                                typeof item.category === 'string' && item.category.trim()
-                                        ? item.category.trim()
-                                        : null;
-
-                        return {
-                                ...(stationName !== null ? { stationName } : {}),
-                                ...(category !== null ? { category } : {}),
-                                score: cleaned
-                        };
-                })
-                .filter(Boolean);
-
-        const completionRecords = [completionFinisherEntry, completionSummaryEntry]
-                .map((entry) => {
-                        if (!entry || !entry.score) return null;
-                        const cleaned = {};
-                        if (Number(entry.score.reps) > 0) cleaned.reps = Number(entry.score.reps);
-                        if (Number(entry.score.cals) > 0) cleaned.cals = Number(entry.score.cals);
-                        if (entry.score.notes && String(entry.score.notes).trim()) {
-                                cleaned.notes = String(entry.score.notes).trim();
-                        }
-                        if (Array.isArray(entry.score.selections) && entry.score.selections.length) {
-                                cleaned.selections = entry.score.selections;
-                        }
-
-                        if (!Object.keys(cleaned).length) {
-                                return null;
-                        }
-
-                        const stationName =
-                                typeof entry.stationName === 'string' && entry.stationName.trim()
-                                        ? entry.stationName.trim()
-                                        : null;
-                        const category =
-                                typeof entry.category === 'string' && entry.category.trim()
-                                        ? entry.category.trim()
-                                        : null;
-
-                        return {
-                                ...(stationName !== null ? { stationName } : {}),
-                                ...(category !== null ? { category } : {}),
-                                score: cleaned
-                        };
-                })
-                .filter(Boolean);
-
-        const combinedScores = [...cleanedScores, ...completionRecords];
-
-        if (!combinedScores.length) {
-                finalSaveStatus = 'error';
-                finalSaveMessage = 'Log at least one score before uploading your workout.';
-                return;
-        }
-
-        try {
-                await addDoc(collection(db, 'scores'), {
-                        userId: $user.uid,
-                        displayName: resolvedDisplayName,
-                        email: userProfile.email ?? '',
-                        workoutId: workout.id,
-                        workoutTitle: workout.title,
-                        sessionId: session.id,
-                        sessionDate: session.sessionDate ?? null,
-                        totalTimeMinutes: totalTime,
-                        date: serverTimestamp(),
-                        exerciseScores: combinedScores
-                });
-
-                const attendanceRef = doc(db, 'attendance', `${session.id}_${$user.uid}`);
-                const sessionAttendanceId = `${session.id}_${$user.uid}`;
-
-                const buildAttendancePayload = () => {
-                        const payload = {
-                                userId: $user.uid,
-                                displayName: resolvedDisplayName,
-                                email: userProfile.email ?? '',
-                                sessionId: session.id,
-                                sessionAttendanceId,
-                                workoutId: workout.id,
-                                workoutTitle: workout.title,
-                                sessionDate: session.sessionDate ?? null,
-                                date: serverTimestamp()
-                        };
-
-                        if (session?.creatorId) {
-                                payload.creatorId = session.creatorId;
-                        }
-
-                        return payload;
-                };
-
-                const attendanceWrite = (async () => {
-                        try {
-                                await setDoc(attendanceRef, buildAttendancePayload(), { merge: true });
-                        } catch (primaryError) {
-                                console.warn('Primary attendance write failed, attempting fallback record.', primaryError);
-                                try {
-                                        await addDoc(collection(db, 'attendance'), {
-                                                ...buildAttendancePayload()
-                                        });
-                                } catch (fallbackError) {
-                                        console.error('Fallback attendance write failed:', fallbackError);
-                                        throw fallbackError;
-                                }
-                        }
-                })();
-
-                const sessionRef = doc(db, 'sessions', session.id);
-                const sessionUpdate = updateDoc(sessionRef, {
-                        attendance: arrayUnion({
-                                userId: $user.uid,
-                                displayName: resolvedDisplayName,
-                                email: userProfile.email ?? ''
-                        })
-                });
-
-                const ratingValue = Number(feedbackRating);
-                const trimmedComment = feedbackComment.trim();
-                const hasRating = Number.isFinite(ratingValue) && ratingValue > 0;
-                const shouldRecordFeedback = hasRating || trimmedComment.length;
-
-                const writes = [
-                        { type: 'attendance-record', promise: attendanceWrite },
-                        { type: 'session-attendance', promise: sessionUpdate }
-                ];
-
-                if (shouldRecordFeedback) {
-                        const feedbackPayload = {
-                                rating: hasRating ? ratingValue : null,
-                                comment: trimmedComment,
-                                createdAt: serverTimestamp()
-                        };
-
-                        const recordFeedback = async () => {
-                                try {
-                                        await addDoc(collection(db, 'sessions', session.id, 'feedback'), feedbackPayload);
-                                } catch (primaryError) {
-                                        console.warn('Primary feedback write failed, attempting fallback collection.', primaryError);
-                                        try {
-                                                await addDoc(collection(db, 'sessionFeedback'), {
-                                                        ...feedbackPayload,
-                                                        sessionId: session.id,
-                                                        workoutId: workout.id,
-                                                        workoutTitle: workout.title,
-                                                        userId: $user.uid,
-                                                        displayName: resolvedDisplayName
-                                                });
-                                        } catch (fallbackError) {
-                                                console.error('Fallback feedback write failed:', fallbackError);
-                                                throw fallbackError;
-                                        }
-                                }
-                        };
-
-                        writes.push({ type: 'feedback', promise: recordFeedback() });
-                }
-
-                const writeResults = await Promise.allSettled(writes.map((entry) => entry.promise));
-                const failureTypes = new Set();
-
-                writeResults.forEach((result, index) => {
-                        if (result.status === 'rejected') {
-                                const { type } = writes[index];
-                                failureTypes.add(type);
-                                if (type === 'session-attendance') {
-                                        console.warn('Session attendance array update failed:', result.reason);
-                                } else {
-                                        console.error('Follow-up write failed:', result.reason);
-                                }
-                        }
-                });
-
-                hasSavedFinalScore = true;
-
-                const attendanceFailed = failureTypes.has('attendance-record');
-                const sessionAttendanceFailed = failureTypes.has('session-attendance');
-                const feedbackFailed = failureTypes.has('feedback');
-
-                if (attendanceFailed) {
-                        finalSaveStatus = 'warning';
-                        finalSaveMessage =
-                                'Workout saved, but we could not record your attendance. Please let your coach know so they can update it.';
-                } else if (feedbackFailed) {
-                        finalSaveStatus = 'warning';
-                        finalSaveMessage =
-                                'Workout saved, but we could not record your feedback. Please try again later or let your coach know.';
-                } else {
-                        finalSaveStatus = 'success';
-                        finalSaveMessage = 'Workout uploaded to your dashboard.';
-
-                        if (sessionAttendanceFailed) {
-                                console.info('Attendance fallback will rely on standalone attendance records for this session.');
-                        }
-                }
-        } catch (error) {
-                console.error('Error saving score:', error);
-                finalSaveStatus = 'error';
-                finalSaveMessage = 'Failed to upload workout. Please try again.';
-        } finally {
-                feedbackRating = 0;
-                feedbackComment = '';
-        }
-}
-
-$: totalStations = workout.exercises?.length ?? 0;
-
-$: if (myScoreRef && userProfile.displayName && workout.mode !== 'Partner' && !hasJoinedRoster && rosterStatus === 'idle') {
-        wantsPartnerPairing = true;
-        joinStationRoster().catch(err => console.error("Auto-join failed:", err));
-}
-
-$: if (
-        myScoreRef &&
-        userProfile.displayName &&
-        workout.mode === 'Partner' &&
-        wantsPartnerPairing &&
-        !hasJoinedRoster &&
-        rosterStatus === 'idle'
-) {
-        joinStationRoster({ trainingSolo: false }).catch(err => console.error("Auto-join partner failed:", err));
-}
-
-$: if (
-        workout.mode === 'Partner' &&
-        !wantsPartnerPairing &&
-        hasJoinedRoster &&
-        rosterStatus === 'idle' &&
-        !isTrainingSolo
-) {
-        void leaveStationRoster();
-}
-
-$: if (userProfile.displayName && hasJoinedRoster) {
-        const assignments = normaliseStationAssignments(
-                liveState.stationAssignments ?? session.stationAssignments,
-                workout.exercises.length
-        );
-        if (assignments.length && liveState.movesCompleted !== undefined) {
-                const uppercaseName = userProfile.displayName?.toUpperCase();
-                let startingIndex = -1;
-                let startingRoster = [];
-                assignments.forEach((roster, index) => {
-                        if (roster.includes(uppercaseName)) {
-                                startingIndex = index;
-                                startingRoster = roster;
-                        }
-                });
-
-                if (startingIndex !== -1) {
-                        const total = workout.exercises.length;
-                        myPartnerSlot = startingRoster.indexOf(uppercaseName);
-                        myCurrentStationIndex = (startingIndex + liveState.movesCompleted) % total;
-                        myNextStationIndex = (myCurrentStationIndex + 1) % total;
-                } else {
-                        myPartnerSlot = -1;
-                        myCurrentStationIndex = -1;
-                        myNextStationIndex = -1;
-                }
-        }
-} else {
-        myPartnerSlot = -1;
-        myCurrentStationIndex = -1;
-        myNextStationIndex = -1;
-}
-
-$: if (hasJoinedRoster && myCurrentStationIndex !== previousStationIndex) {
-        if (previousStationIndex !== -1) {
-                void commitStationScore(previousStationIndex, { auto: true });
-        }
-        previousStationIndex = myCurrentStationIndex;
-        if (myCurrentStationIndex !== lastSavedStationIndex) {
-                lastSaveMessage = '';
-                lastSaveType = 'idle';
-        }
-}
-
-$: if (liveState.isComplete && !previousCompletionState) {
-        previousCompletionState = true;
-        if (myCurrentStationIndex !== -1) {
-                void commitStationScore(myCurrentStationIndex, { auto: true });
-        }
-} else if (!liveState.isComplete && previousCompletionState) {
-        previousCompletionState = false;
-}
-
-$: myStationData = myCurrentStationIndex !== -1 ? workout.exercises[myCurrentStationIndex] : null;
-$: nextStationData = myNextStationIndex !== -1 ? workout.exercises[myNextStationIndex] : null;
-$: nextStationCategory = nextStationData
-        ? normaliseCategory(
-                  workout.mode === 'Partner'
-                          ? nextStationData.p1?.category || nextStationData.category
-                          : nextStationData.category,
-                  DEFAULT_CATEGORY
-          )
-        : '';
-$: intervalDuration = liveState?.duration || liveState?.timing?.work || session?.timing?.work || null;
-$: hasPendingForCurrent = myCurrentStationIndex >= 0 && pendingStations.has(myCurrentStationIndex);
-$: chipperSteps = isChipperMode ? workout.chipper?.steps ?? [] : [];
-$: chipperGroups = isChipperMode ? buildChipperGroups(chipperSteps) : [];
-$: chipperFinisher = isChipperMode ? workout.chipper?.finisher ?? null : null;
-$: chipperFinisherName =
-        chipperFinisher?.name && chipperFinisher.name.trim()
-                ? chipperFinisher.name.trim()
-                : 'Chipper Finisher';
-$: chipperFinisherCategory = normaliseCategory(
-        chipperFinisher?.category,
-        'Cardio Machine'
-);
-$: finisherMetric = isChipperMode ? getFinisherMetricForCategory(chipperFinisherCategory) : null;
-$: if (isChipperMode && chipperSteps.length) {
-        const names = chipperSteps.map((step) => step?.name ?? '');
-        if (!completionForm.progressExercise || !names.includes(completionForm.progressExercise)) {
-                completionForm = { ...completionForm, progressExercise: names[0] ?? '' };
-        }
-}
-
-$: currentP1Task = myStationData?.p1?.task ? String(myStationData.p1.task).trim() : '';
-$: currentP2Task = myStationData?.p2?.task ? String(myStationData.p2.task).trim() : '';
-$: stationCategory = myStationData ? normaliseCategory(myStationData.category, DEFAULT_CATEGORY) : DEFAULT_CATEGORY;
-$: primaryTaskDetails = myStationData
-        ? {
-                  name: currentP1Task || myStationData.name || '',
-                  category: normaliseCategory(myStationData.p1?.category, stationCategory)
-          }
-        : { name: '', category: DEFAULT_CATEGORY };
-$: secondaryTaskDetails = myStationData
-        ? {
-                  name: currentP2Task || primaryTaskDetails.name || myStationData.name || '',
-                  category: normaliseCategory(myStationData.p2?.category, primaryTaskDetails.category)
-          }
-        : { name: '', category: DEFAULT_CATEGORY };
-$: {
-        if (myStationData && Array.isArray(myStationData.equipment)) {
-                const cleaned = myStationData.equipment
-                        .map((item) => (typeof item === 'string' ? item.trim() : ''))
-                        .filter((item) => item.length > 0);
-                equipmentOptions = Array.from(new Set(cleaned));
-        } else {
-                equipmentOptions = [];
-        }
-}
-$: selectedEquipment =
-        myCurrentStationIndex >= 0 && currentEntries[myCurrentStationIndex]
-                ? String(currentEntries[myCurrentStationIndex].score.selection || '')
-                : '';
-$: equipmentHistory =
-        myCurrentStationIndex >= 0 &&
-        Array.isArray(cumulativeScores[myCurrentStationIndex]?.score?.selections)
-                ? Array.from(
-                          new Set(
-                                  cumulativeScores[myCurrentStationIndex].score.selections
-                                          .map((item) => (typeof item === 'string' ? item.trim() : ''))
-                                          .filter(Boolean)
-                          )
-                  )
-                : [];
-$: isRestPhase = liveState?.phaseType === 'rest';
-$: if (workout.mode === 'Partner') {
-        if (myPartnerSlot === 0) {
-                myPartnerRole = 'Partner A';
-        } else if (myPartnerSlot === 1) {
-                myPartnerRole = 'Partner B';
-        } else if (myPartnerSlot >= 0) {
-                myPartnerRole = `Partner ${myPartnerSlot + 1}`;
-        } else {
-                myPartnerRole = '';
-        }
-} else {
-        myPartnerRole = '';
-}
-$: {
-        if (!myStationData) {
-                soloPrimaryTask = '';
-                soloSecondaryTask = '';
-                myActiveTaskLabel = '';
-                activeTask = { name: '', category: DEFAULT_CATEGORY };
-                upcomingTask = null;
-                metricCategory = DEFAULT_CATEGORY;
-        } else {
-                const fallbackName = myStationData.name || '';
-                const primaryName = primaryTaskDetails.name || fallbackName;
-                const secondaryName = secondaryTaskDetails.name || primaryName;
-                const hasDistinctSecondary = Boolean(secondaryTaskDetails.name && secondaryName !== primaryName);
-                const isSecondWorkBlock = liveState?.phaseIndex === 2;
-
-                soloPrimaryTask = primaryName;
-                soloSecondaryTask = hasDistinctSecondary ? secondaryName : '';
-
-                let nextActive = { ...primaryTaskDetails, name: primaryName };
-                let nextUpcoming = hasDistinctSecondary ? { ...secondaryTaskDetails, name: secondaryName } : null;
-
-                if (workout.mode === 'Partner') {
-                        if (isTrainingSolo || myPartnerSlot === 0) {
-                                if (isSecondWorkBlock && hasDistinctSecondary) {
-                                        nextActive = { ...secondaryTaskDetails, name: secondaryName };
-                                        nextUpcoming = null;
-                                }
-                        } else if (myPartnerSlot === 1) {
-                                if (!isSecondWorkBlock && hasDistinctSecondary) {
-                                        nextActive = { ...secondaryTaskDetails, name: secondaryName };
-                                        nextUpcoming = { ...primaryTaskDetails, name: primaryName };
-                                } else {
-                                        nextActive = { ...primaryTaskDetails, name: primaryName };
-                                        nextUpcoming = null;
-                                }
-                        } else if (myPartnerSlot >= 0) {
-                                nextActive = { ...primaryTaskDetails, name: primaryName };
-                                nextUpcoming = hasDistinctSecondary ? { ...secondaryTaskDetails, name: secondaryName } : null;
-                        }
-                } else if (!hasDistinctSecondary) {
-                        nextUpcoming = null;
-                }
-
-                activeTask = nextActive;
-                upcomingTask = nextUpcoming;
-                myActiveTaskLabel = activeTask.name || fallbackName || primaryName;
-                metricCategory = activeTask.category || stationCategory || DEFAULT_CATEGORY;
-        }
-}
-$: metricLabel = myStationData ? getMetricLabelForCategory(metricCategory) : '';
-$: hasSessionStarted = Number.isFinite(liveState?.phaseIndex) && liveState.phaseIndex >= 0 && !liveState.isComplete;
-$: showPairingControls = workout.mode === 'Partner' && !hasSessionStarted;
-$: {
-        if (rosterStatus === 'joining') {
-                partnerStatusText = 'Adding you to the partner rotation...';
-        } else if (rosterStatus === 'leaving') {
-                partnerStatusText = 'Updating your selection...';
-        } else if (isTrainingSolo) {
-                if (hasJoinedRoster) {
-                        partnerStatusText = "You're locked in to train solo for this partner session.";
-                } else if (rosterError) {
-                        partnerStatusText = "We're unable to add you just yet. Please review the message below.";
-                } else {
-                        partnerStatusText = "We'll load your solo station as soon as it's assigned.";
-                }
-        } else if (wantsPartnerPairing) {
-                if (hasJoinedRoster) {
-                        partnerStatusText = "You're set to rotate with a partner.";
-                } else if (rosterError) {
-                        partnerStatusText = "We're unable to add you just yet. Please review the message below.";
-                } else {
-                        partnerStatusText = "We'll add you as soon as there's an open station.";
-                }
-        } else {
-                partnerStatusText = "You're logged to train solo for this session.";
-        }
-}
-
-function formatTime(s) {
-        const secs = Math.max(0, Math.ceil(s));
-        return String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0');
-}
+	// @ts-nocheck
+	import { onMount } from 'svelte';
+	import { db } from '$lib/firebase';
+	import {
+		normaliseStationAssignments,
+		serialiseStationAssignments
+	} from '$lib/stationAssignments';
+	import { buildChipperGroups } from '$lib/chipper';
+	import {
+		doc,
+		onSnapshot,
+		addDoc,
+		serverTimestamp,
+		collection,
+		setDoc,
+		runTransaction,
+		deleteDoc,
+		updateDoc,
+		arrayUnion
+	} from 'firebase/firestore';
+	import { user } from '$lib/store';
+
+	export let data;
+	const { session, workout } = data;
+	const isChipperMode = workout.mode === 'Chipper';
+
+	let chipperGroups = [];
+	let chipperFinisher = null;
+	let chipperSteps = [];
+
+	let liveState = {
+		phase: 'Connecting...',
+		remaining: 0,
+		currentStation: 0,
+		isComplete: false,
+		movesCompleted: 0
+	};
+
+	let userProfile = {};
+	let myCurrentStationIndex = -1;
+	let myNextStationIndex = -1;
+	let previousStationIndex = -1;
+
+	let hasSavedFinalScore = false;
+	let hasJoinedRoster = false;
+	let wantsPartnerPairing = workout.mode !== 'Partner';
+	let pairingLocked = workout.mode !== 'Partner';
+	let isTrainingSolo = false;
+
+	let myPartnerSlot = -1;
+	let myPartnerRole = '';
+	let myActiveTaskLabel = '';
+	let currentP1Task = '';
+	let currentP2Task = '';
+	let soloPrimaryTask = '';
+	let soloSecondaryTask = '';
+	const DEFAULT_CATEGORY = 'Bodyweight';
+	let stationCategory = DEFAULT_CATEGORY;
+	let primaryTaskDetails = { name: '', category: DEFAULT_CATEGORY };
+	let secondaryTaskDetails = { name: '', category: DEFAULT_CATEGORY };
+	let activeTask = { name: '', category: DEFAULT_CATEGORY };
+	let upcomingTask = null;
+	let metricCategory = DEFAULT_CATEGORY;
+	let equipmentOptions = [];
+	let selectedEquipment = '';
+	let equipmentHistory = [];
+	let isRestPhase = false;
+	let hasSessionStarted = false;
+	let showPairingControls = workout.mode === 'Partner';
+	let nextStationCategory = '';
+
+	let rosterStatus = 'idle';
+	let rosterError = '';
+	let partnerStatusText = '';
+
+	let myScoreRef = null;
+	let unsubscribe = [];
+
+	const createEntryScore = () => ({
+		reps: '',
+		weight: '',
+		cals: '',
+		dist: '',
+		notes: '',
+		selection: ''
+	});
+	const createCumulativeScore = () => ({
+		reps: 0,
+		weight: 0,
+		cals: 0,
+		dist: '',
+		notes: '',
+		selections: []
+	});
+
+	function normaliseCategory(category, fallback = '') {
+		const raw = String(category ?? '').trim();
+		if (!raw) return fallback;
+		const lower = raw.toLowerCase();
+		if (lower.includes('cardio')) return 'Cardio Machine';
+		if (lower.includes('resist') || lower.includes('strength') || lower.includes('weight'))
+			return 'Resistance';
+		if (lower.includes('body')) return 'Bodyweight';
+		return raw;
+	}
+
+	function getMetricLabelForCategory(category) {
+		switch (category) {
+			case 'Resistance':
+				return 'Reps & Weight';
+			case 'Cardio Machine':
+				return 'Calories & Distance';
+			case 'Bodyweight':
+				return 'Reps';
+			default:
+				return category || '';
+		}
+	}
+
+	function formatDistance(value) {
+		if (!value) return '';
+		const trimmed = String(value).trim();
+		if (!trimmed) return '';
+		const lower = trimmed.toLowerCase();
+		if (lower.endsWith('m') || lower.endsWith('km')) {
+			return trimmed;
+		}
+		if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+			return `${trimmed}m`;
+		}
+		return trimmed;
+	}
+
+	function getFinisherMetricForCategory(category) {
+		const normalised = normaliseCategory(category, '');
+		if (normalised === 'Cardio Machine') {
+			return { key: 'cals', label: 'Calories', placeholder: 'e.g. 80' };
+		}
+		if (normalised === 'Bodyweight' || normalised === 'Resistance') {
+			return { key: 'reps', label: 'Reps', placeholder: 'e.g. 45' };
+		}
+		return { key: 'reps', label: 'Score', placeholder: 'Enter result' };
+	}
+
+	let currentEntries = workout.exercises.map((ex) => ({
+		stationName: ex.name ?? '',
+		category: ex.category ?? '',
+		score: createEntryScore()
+	}));
+
+	let cumulativeScores = workout.exercises.map((ex) => ({
+		stationName: ex.name ?? '',
+		category: ex.category ?? '',
+		score: createCumulativeScore()
+	}));
+
+	let pendingStations = new Set();
+	let chipperFinisherName = '';
+	let chipperFinisherCategory = DEFAULT_CATEGORY;
+	let completedChipperSteps = new Set();
+
+	const isAmrapType = String(workout?.type ?? '').toLowerCase() === 'amrap';
+	const requiresCompletionLog = isChipperMode || isAmrapType;
+
+	let showCompletionModal = false;
+	let completionError = '';
+	let completionForm = {
+		finisherValue: '',
+		completedChipper: false,
+		progressExercise: '',
+		progressReps: '',
+		amrapRounds: '',
+		amrapReps: ''
+	};
+	let amrapRoundCount = 0;
+	let amrapExtraReps = 0;
+	let completionSummaryEntry = null;
+	let completionFinisherEntry = null;
+	let finisherMetric = null;
+
+	let lastSavedStationIndex = -1;
+	let lastSaveMessage = '';
+	let lastSaveType = 'idle';
+
+	let finalSaveStatus = 'idle';
+	let finalSaveMessage = '';
+	let previousCompletionState = false;
+	let totalTime = 0;
+
+	let showFeedbackModal = false;
+	let feedbackRating = 0;
+	let feedbackComment = '';
+	let uploadWeightSummary = '';
+	let uploadCompletionSummary = '';
+
+	function formatAmrapSummary(rounds, reps) {
+		const movementName = workout?.exercises?.[0]?.name?.trim();
+		let summaryNote = `Completed ${rounds} round${rounds === 1 ? '' : 's'}`;
+
+		if (reps > 0) {
+			const movementLabel = movementName
+				? `${movementName}${reps === 1 ? '' : 's'}`
+				: `rep${reps === 1 ? '' : 's'}`;
+			summaryNote += ` + ${reps} ${movementLabel}`;
+		}
+
+		return summaryNote;
+	}
+
+	function buildWeightSummary() {
+		const weightEntries = cumulativeScores
+			.map((entry, index) => {
+				const weightValue = Number(entry.score.weight);
+				if (!Number.isFinite(weightValue) || weightValue <= 0) return null;
+
+				const stationLabel = entry.stationName?.trim()
+					? entry.stationName.trim()
+					: `Station ${index + 1}`;
+
+				return `${stationLabel}: ${weightValue} kg`;
+			})
+			.filter(Boolean);
+
+		if (!weightEntries.length) {
+			return 'No weight logged during this session.';
+		}
+
+		return `Weight used – ${weightEntries.join(' • ')}`;
+	}
+
+	function buildCompletionSummary() {
+		if (completionSummaryEntry?.score?.notes) {
+			return completionSummaryEntry.score.notes;
+		}
+
+		if (isAmrapType && (amrapRoundCount > 0 || amrapExtraReps > 0)) {
+			return formatAmrapSummary(amrapRoundCount, amrapExtraReps);
+		}
+
+		if (isChipperMode && completedChipperSteps.size > 0) {
+			return `Completed ${completedChipperSteps.size} chipper movement${completedChipperSteps.size === 1 ? '' : 's'}.`;
+		}
+
+		return 'Workout log ready to upload.';
+	}
+
+	function toggleChipperStepCompletion(order) {
+		const next = new Set(completedChipperSteps);
+		if (next.has(order)) {
+			next.delete(order);
+		} else {
+			next.add(order);
+		}
+		completedChipperSteps = next;
+	}
+
+	function syncAmrapCompletion(roundsValue = amrapRoundCount, extraValue = amrapExtraReps) {
+		const safeRounds = Math.max(0, Math.floor(Number(roundsValue) || 0));
+		const safeReps = Math.max(0, Math.floor(Number(extraValue) || 0));
+
+		amrapRoundCount = safeRounds;
+		amrapExtraReps = safeReps;
+
+		completionForm = {
+			...completionForm,
+			amrapRounds: String(safeRounds),
+			amrapReps: String(safeReps)
+		};
+
+		if (safeRounds === 0 && safeReps === 0) {
+			completionSummaryEntry = null;
+			return;
+		}
+
+		const summaryNote = formatAmrapSummary(safeRounds, safeReps);
+
+		completionSummaryEntry = {
+			stationName: 'AMRAP Result',
+			category: 'AMRAP',
+			score: { notes: summaryNote }
+		};
+		completionFinisherEntry = null;
+	}
+
+	function adjustAmrapRounds(delta) {
+		if (!isAmrapType) return;
+		const next = Math.max(0, amrapRoundCount + delta);
+		syncAmrapCompletion(next, amrapExtraReps);
+	}
+
+	function handleAmrapRepsInput(event) {
+		const value = event?.currentTarget?.value ?? event?.target?.value ?? '0';
+		syncAmrapCompletion(amrapRoundCount, value);
+	}
+
+	$: if (!isChipperMode && completedChipperSteps.size) {
+		completedChipperSteps = new Set();
+	}
+
+	$: if (isChipperMode) {
+		const availableOrders = new Set(chipperSteps.map((_, index) => index + 1));
+		const filteredOrders = [...completedChipperSteps].filter((order) => availableOrders.has(order));
+		if (filteredOrders.length !== completedChipperSteps.size) {
+			completedChipperSteps = new Set(filteredOrders);
+		}
+	}
+
+	onMount(() => {
+		const userUid = $user?.uid;
+		if (!userUid) return;
+
+		myScoreRef = doc(db, 'sessions', session.id, 'attendees', userUid);
+
+		const profileRef = doc(db, 'profiles', userUid);
+		const unsubProfile = onSnapshot(profileRef, (docSnap) => {
+			if (docSnap.exists()) {
+				userProfile = docSnap.data();
+			}
+		});
+
+		const liveStateRef = doc(db, 'sessions', session.id, 'liveState', 'data');
+		const unsubState = onSnapshot(liveStateRef, (docSnap) => {
+			if (docSnap.exists()) {
+				liveState = docSnap.data();
+			}
+		});
+
+		const unsubScore = onSnapshot(myScoreRef, (docSnap) => {
+			const didJoin = docSnap.exists();
+			if (didJoin !== hasJoinedRoster) {
+				hasJoinedRoster = didJoin;
+			}
+			if (workout.mode === 'Partner') {
+				if (didJoin) {
+					if (!isTrainingSolo && !pairingLocked) {
+						wantsPartnerPairing = true;
+					}
+				} else if (!pairingLocked) {
+					wantsPartnerPairing = false;
+					isTrainingSolo = false;
+				}
+			}
+		});
+
+		unsubscribe = [unsubProfile, unsubState, unsubScore];
+
+		return () => unsubscribe.forEach((unsub) => unsub && unsub());
+	});
+
+	function setEntryScore(index, newScore) {
+		const next = [...currentEntries];
+		next[index] = { ...next[index], score: newScore };
+		currentEntries = next;
+	}
+
+	function setCumulativeScore(index, newScore) {
+		const next = [...cumulativeScores];
+		next[index] = { ...next[index], score: newScore };
+		cumulativeScores = next;
+	}
+
+	function resetEntry(index) {
+		setEntryScore(index, createEntryScore());
+	}
+
+	function hasEntryValue(entry) {
+		if (!entry) return false;
+		return (
+			['reps', 'weight', 'cals'].some((key) => Number(entry[key]) > 0) ||
+			(entry.dist && entry.dist.trim().length > 0) ||
+			(entry.notes && entry.notes.trim().length > 0) ||
+			(entry.selection && String(entry.selection).trim().length > 0)
+		);
+	}
+
+	function handleEntryChange(index, field, rawValue) {
+		if (index < 0 || !currentEntries[index]) return;
+
+		const entry = { ...currentEntries[index].score };
+		if (field === 'dist') {
+			entry.dist = rawValue;
+		} else if (field === 'notes') {
+			entry.notes = rawValue;
+		} else {
+			const numeric = Number(rawValue);
+			entry[field] = rawValue === '' ? '' : Math.max(0, Number.isFinite(numeric) ? numeric : 0);
+		}
+
+		setEntryScore(index, entry);
+
+		if (hasEntryValue(entry)) {
+			pendingStations.add(index);
+		} else {
+			pendingStations.delete(index);
+		}
+		pendingStations = new Set(pendingStations);
+
+		if (lastSavedStationIndex === index && !hasEntryValue(entry)) {
+			lastSaveMessage = '';
+			lastSaveType = 'idle';
+		}
+	}
+
+	function handleSelectionChange(index, option) {
+		if (index < 0 || !currentEntries[index]) return;
+
+		const trimmed = typeof option === 'string' ? option.trim() : '';
+		const entry = { ...currentEntries[index].score, selection: trimmed };
+
+		setEntryScore(index, entry);
+
+		if (hasEntryValue(entry)) {
+			pendingStations.add(index);
+		} else {
+			pendingStations.delete(index);
+		}
+		pendingStations = new Set(pendingStations);
+
+		if (lastSavedStationIndex === index && !hasEntryValue(entry)) {
+			lastSaveMessage = '';
+			lastSaveType = 'idle';
+		}
+	}
+
+	async function commitStationScore(index, { auto = false } = {}) {
+		if (!hasJoinedRoster || index < 0 || !currentEntries[index]) return;
+
+		const entry = currentEntries[index].score;
+		if (!hasEntryValue(entry)) {
+			pendingStations.delete(index);
+			pendingStations = new Set(pendingStations);
+			resetEntry(index);
+			if (!auto) {
+				lastSavedStationIndex = index;
+				lastSaveType = 'info';
+				lastSaveMessage = 'Add a value before saving.';
+			}
+			return;
+		}
+
+		const cumulative = { ...cumulativeScores[index].score };
+		const selectionHistory = Array.isArray(cumulative.selections) ? [...cumulative.selections] : [];
+		const numericFields = ['reps', 'weight', 'cals'];
+		let hasUpdates = false;
+
+		numericFields.forEach((field) => {
+			const amount = Number(entry[field]);
+			if (Number.isFinite(amount) && amount > 0) {
+				cumulative[field] = (cumulative[field] || 0) + amount;
+				hasUpdates = true;
+			}
+		});
+
+		const formattedDistance = formatDistance(entry.dist);
+		if (formattedDistance) {
+			cumulative.dist = cumulative.dist
+				? `${cumulative.dist} + ${formattedDistance}`
+				: formattedDistance;
+			hasUpdates = true;
+		}
+
+		if (entry.notes && entry.notes.trim()) {
+			const trimmedNotes = entry.notes.trim();
+			cumulative.notes = cumulative.notes ? `${cumulative.notes}\n${trimmedNotes}` : trimmedNotes;
+			hasUpdates = true;
+		}
+
+		if (entry.selection && entry.selection.trim()) {
+			const trimmedSelection = entry.selection.trim();
+			selectionHistory.push(trimmedSelection);
+			cumulative.selections = selectionHistory;
+			hasUpdates = true;
+		} else {
+			cumulative.selections = selectionHistory;
+		}
+
+		if (!hasUpdates) {
+			pendingStations.delete(index);
+			pendingStations = new Set(pendingStations);
+			resetEntry(index);
+			return;
+		}
+
+		setCumulativeScore(index, cumulative);
+		pendingStations.delete(index);
+		pendingStations = new Set(pendingStations);
+		resetEntry(index);
+
+		try {
+			await updateLiveScore(cumulative);
+			lastSavedStationIndex = index;
+			lastSaveType = auto ? 'auto' : 'success';
+			lastSaveMessage = auto ? 'Saved automatically for your last station.' : 'Score saved!';
+		} catch (error) {
+			console.error('Failed to update live score', error);
+			lastSavedStationIndex = index;
+			lastSaveType = 'error';
+			lastSaveMessage = 'Could not save your score. Please try again.';
+		}
+	}
+
+	async function updateLiveScore(scoreObject) {
+		if (!hasJoinedRoster || !myScoreRef) return;
+
+		const cleanedScore = {};
+		['reps', 'weight', 'cals'].forEach((field) => {
+			const value = Number(scoreObject[field]);
+			if (Number.isFinite(value) && value > 0) {
+				cleanedScore[field] = value;
+			}
+		});
+		const formattedDistance = formatDistance(scoreObject.dist);
+		if (formattedDistance) {
+			cleanedScore.dist = formattedDistance;
+		}
+
+		if (scoreObject.notes && String(scoreObject.notes).trim()) {
+			cleanedScore.notes = String(scoreObject.notes).trim();
+		}
+
+		if (Array.isArray(scoreObject.selections) && scoreObject.selections.length) {
+			cleanedScore.selections = scoreObject.selections;
+		}
+
+		try {
+			await setDoc(
+				myScoreRef,
+				{
+					displayName: userProfile.displayName ?? '',
+					score: cleanedScore,
+					currentStation: myCurrentStationIndex >= 0 ? myCurrentStationIndex + 1 : 0,
+					updatedAt: serverTimestamp()
+				},
+				{ merge: true }
+			);
+		} catch (error) {
+			console.error('Failed to sync live score', error);
+			throw error;
+		}
+	}
+
+	async function joinStationRoster({ trainingSolo = false } = {}) {
+		if (rosterStatus === 'joining' || hasJoinedRoster || !$user?.uid || !myScoreRef) return;
+
+		const displayName = (userProfile.displayName || '').trim();
+		const totalStations = workout.exercises?.length ?? 0;
+
+		if (!displayName) {
+			rosterError = 'Add your display name in your profile to join the rotation.';
+			return;
+		}
+		if (!totalStations) {
+			rosterError = 'This workout has no stations configured yet.';
+			return;
+		}
+
+		const uppercaseName = displayName.toUpperCase();
+		const sessionRef = doc(db, 'sessions', session.id);
+
+		rosterStatus = 'joining';
+		rosterError = '';
+
+		try {
+			await runTransaction(db, async (transaction) => {
+				const snap = await transaction.get(sessionRef);
+				if (!snap.exists()) return;
+
+				const data = snap.data();
+				let assignments = normaliseStationAssignments(data?.stationAssignments, totalStations);
+
+				if (assignments.length < totalStations) {
+					assignments = assignments.concat(
+						Array.from({ length: totalStations - assignments.length }, () => [])
+					);
+				} else if (assignments.length > totalStations) {
+					assignments = assignments.slice(0, totalStations);
+				}
+
+				assignments = assignments.map((codes) => codes.filter((code) => code !== uppercaseName));
+
+				const counts = assignments.map((codes) => codes.length);
+				const minCount = counts.length ? Math.min(...counts) : 0;
+				let targetIndex = counts.findIndex((count) => count === minCount);
+				if (targetIndex === -1) targetIndex = 0;
+
+				assignments[targetIndex] = [...(assignments[targetIndex] ?? []), uppercaseName];
+
+				transaction.set(
+					sessionRef,
+					{ stationAssignments: serialiseStationAssignments(assignments, totalStations) },
+					{ merge: true }
+				);
+			});
+
+			await setDoc(
+				myScoreRef,
+				{ displayName, score: {}, currentStation: 0, joinedAt: serverTimestamp() },
+				{ merge: true }
+			);
+
+			hasJoinedRoster = true;
+			if (workout.mode === 'Partner') {
+				isTrainingSolo = trainingSolo;
+				wantsPartnerPairing = !trainingSolo;
+			} else {
+				wantsPartnerPairing = true;
+			}
+		} catch (error) {
+			console.error('Failed to join station roster', error);
+			rosterError = 'Could not join the rotation. Please try again.';
+		} finally {
+			rosterStatus = 'idle';
+		}
+	}
+
+	async function leaveStationRoster() {
+		if (rosterStatus === 'leaving' || !$user?.uid || !hasJoinedRoster || !myScoreRef) return;
+
+		const displayName = (userProfile.displayName || '').trim();
+		const uppercaseName = displayName.toUpperCase();
+		const totalStations = workout.exercises?.length ?? 0;
+		const sessionRef = doc(db, 'sessions', session.id);
+
+		rosterStatus = 'leaving';
+		rosterError = '';
+
+		try {
+			if (uppercaseName && totalStations) {
+				await runTransaction(db, async (transaction) => {
+					const snap = await transaction.get(sessionRef);
+					if (!snap.exists()) return;
+
+					const data = snap.data();
+					let assignments = normaliseStationAssignments(data?.stationAssignments, totalStations);
+					assignments = assignments.map((codes) => codes.filter((code) => code !== uppercaseName));
+
+					transaction.set(
+						sessionRef,
+						{ stationAssignments: serialiseStationAssignments(assignments, totalStations) },
+						{ merge: true }
+					);
+				});
+			}
+
+			await deleteDoc(myScoreRef);
+
+			hasJoinedRoster = false;
+			if (workout.mode === 'Partner') {
+				if (!pairingLocked) {
+					wantsPartnerPairing = false;
+				}
+				isTrainingSolo = false;
+				myPartnerSlot = -1;
+			} else {
+				wantsPartnerPairing = false;
+			}
+			myCurrentStationIndex = -1;
+			myNextStationIndex = -1;
+			previousStationIndex = -1;
+		} catch (error) {
+			console.error('Failed to leave station roster', error);
+			rosterError = 'Could not update the roster. Please try again.';
+		} finally {
+			rosterStatus = 'idle';
+		}
+	}
+
+	function selectSoloMode() {
+		if (workout.mode !== 'Partner' || pairingLocked || rosterStatus !== 'idle') return;
+
+		isTrainingSolo = true;
+		wantsPartnerPairing = false;
+		pairingLocked = true;
+		rosterError = '';
+
+		if (!hasJoinedRoster) {
+			void joinStationRoster({ trainingSolo: true });
+		}
+	}
+
+	function selectPartnerMode() {
+		if (workout.mode !== 'Partner' || pairingLocked || rosterStatus !== 'idle') return;
+
+		isTrainingSolo = false;
+		wantsPartnerPairing = true;
+		pairingLocked = true;
+		rosterError = '';
+
+		if (!hasJoinedRoster) {
+			void joinStationRoster({ trainingSolo: false });
+		}
+	}
+
+	function hasTotals(index) {
+		if (index < 0 || !cumulativeScores[index]) return false;
+		const totals = cumulativeScores[index].score;
+		return (
+			['reps', 'weight', 'cals'].some((key) => Number(totals[key]) > 0) ||
+			(totals.dist && totals.dist.trim()) ||
+			(totals.notes && totals.notes.trim())
+		);
+	}
+
+	function hasLoggedScores() {
+		return cumulativeScores.some((item) => {
+			const score = item?.score;
+			if (!score) return false;
+			return (
+				Number(score.reps) > 0 ||
+				Number(score.weight) > 0 ||
+				Number(score.cals) > 0 ||
+				(score.dist && String(score.dist).trim().length > 0) ||
+				(score.notes && String(score.notes).trim().length > 0)
+			);
+		});
+	}
+
+	function hasCompletionEntries() {
+		return Boolean(completionSummaryEntry) || Boolean(completionFinisherEntry);
+	}
+
+	function completionLogComplete() {
+		if (!requiresCompletionLog) return true;
+		if (isChipperMode) {
+			const needsFinisher = Boolean(finisherMetric);
+			return (
+				Boolean(completionSummaryEntry) && (!needsFinisher || Boolean(completionFinisherEntry))
+			);
+		}
+		if (isAmrapType) {
+			return Boolean(completionSummaryEntry);
+		}
+		return true;
+	}
+
+	function openCompletionModal() {
+		completionError = '';
+		if (isChipperMode && !completionForm.progressExercise && chipperSteps.length) {
+			completionForm = { ...completionForm, progressExercise: chipperSteps[0]?.name ?? '' };
+		} else {
+			completionForm = { ...completionForm };
+		}
+		showCompletionModal = true;
+	}
+
+	function cancelCompletionModal() {
+		completionError = '';
+		showCompletionModal = false;
+	}
+
+	function proceedToUpload() {
+		if (!hasLoggedScores() && !hasCompletionEntries()) {
+			finalSaveStatus = 'error';
+			finalSaveMessage = 'Log at least one score before uploading your workout.';
+			return;
+		}
+
+		feedbackRating = 0;
+		feedbackComment = '';
+		finalSaveStatus = 'idle';
+		finalSaveMessage = '';
+		uploadWeightSummary = buildWeightSummary();
+		uploadCompletionSummary = buildCompletionSummary();
+		showFeedbackModal = true;
+	}
+
+	function submitCompletionForm() {
+		completionError = '';
+
+		if (isChipperMode) {
+			const metric = finisherMetric;
+			const metricValue = Number(completionForm.finisherValue);
+			const metricValid = !metric || (Number.isFinite(metricValue) && metricValue > 0);
+			const completedChipper = Boolean(completionForm.completedChipper);
+			const trimmedExercise = String(completionForm.progressExercise || '').trim();
+			const repsValue = Number(completionForm.progressReps);
+			const repsValid = Number.isFinite(repsValue) && repsValue >= 0;
+			const hasChipperSteps = Array.isArray(chipperSteps) && chipperSteps.length > 0;
+
+			if (!metricValid) {
+				const label = metric?.label?.toLowerCase() ?? 'result';
+				completionError = `Enter the ${label} you finished with.`;
+				return;
+			}
+
+			if (!completedChipper && hasChipperSteps) {
+				if (!trimmedExercise) {
+					completionError = 'Select the exercise you reached before time capped.';
+					return;
+				}
+				if (!repsValid) {
+					completionError = 'Enter the reps completed before the clock ran out.';
+					return;
+				}
+			}
+
+			const safeMetric = metric ? Math.round(metricValue) : null;
+			const safeReps = Number.isFinite(repsValue) ? Math.max(0, Math.floor(repsValue)) : 0;
+
+			completionForm = {
+				...completionForm,
+				finisherValue: metric && safeMetric !== null ? String(safeMetric) : '',
+				progressReps: completedChipper ? '' : String(safeReps)
+			};
+
+			if (metric) {
+				const metricKey = metric.key === 'cals' ? 'cals' : 'reps';
+				completionFinisherEntry = {
+					stationName: chipperFinisherName || 'Chipper Finisher',
+					category: chipperFinisherCategory,
+					score: { [metricKey]: safeMetric ?? 0 }
+				};
+			} else {
+				completionFinisherEntry = null;
+			}
+
+			let summaryNote = 'Completed the entire chipper before the time cap.';
+			if (!completedChipper) {
+				summaryNote =
+					hasChipperSteps && trimmedExercise
+						? `Time capped on ${trimmedExercise} at ${safeReps} rep${safeReps === 1 ? '' : 's'}.`
+						: `Time capped with ${safeReps} rep${safeReps === 1 ? '' : 's'} remaining.`;
+			}
+
+			completionSummaryEntry = {
+				stationName: 'Chipper Progress',
+				category: 'Chipper',
+				score: { notes: summaryNote }
+			};
+		} else if (isAmrapType) {
+			const roundsValue = Number(completionForm.amrapRounds);
+			const extraValue = Number(completionForm.amrapReps);
+			const hasRounds = Number.isFinite(roundsValue) && roundsValue >= 0;
+			const hasExtra = Number.isFinite(extraValue) && extraValue >= 0;
+
+			if (!hasRounds || !hasExtra) {
+				completionError = 'Enter the rounds and remaining reps to finish.';
+				return;
+			}
+
+			const safeRounds = Math.max(0, Math.floor(roundsValue));
+			const safeReps = Math.max(0, Math.floor(extraValue));
+
+			if (safeRounds === 0 && safeReps === 0) {
+				completionError = 'Log at least one round or rep to complete the AMRAP.';
+				return;
+			}
+
+			completionForm = {
+				...completionForm,
+				amrapRounds: String(safeRounds),
+				amrapReps: String(safeReps)
+			};
+
+			syncAmrapCompletion(safeRounds, safeReps);
+
+			const summaryNote = formatAmrapSummary(safeRounds, safeReps);
+
+			completionSummaryEntry = {
+				stationName: 'AMRAP Result',
+				category: 'AMRAP',
+				score: { notes: summaryNote }
+			};
+			completionFinisherEntry = null;
+		}
+
+		showCompletionModal = false;
+		proceedToUpload();
+	}
+
+	function startUpload() {
+		if (finalSaveStatus === 'saving' || hasSavedFinalScore) return;
+
+		if (!completionLogComplete()) {
+			openCompletionModal();
+			return;
+		}
+
+		proceedToUpload();
+	}
+
+	function handleFeedbackSubmit(includeFeedback) {
+		if (!includeFeedback) {
+			feedbackRating = 0;
+			feedbackComment = '';
+		}
+		showFeedbackModal = false;
+		void saveFinalScores();
+	}
+
+	function cancelFeedback() {
+		showFeedbackModal = false;
+	}
+
+	async function saveFinalScores() {
+		if (hasSavedFinalScore || !$user?.uid) return;
+
+		if (!completionLogComplete()) {
+			finalSaveStatus = 'error';
+			finalSaveMessage = 'Finish logging your workout before uploading.';
+			return;
+		}
+
+		showFeedbackModal = false;
+		finalSaveStatus = 'saving';
+		finalSaveMessage = '';
+
+		const displayName = (userProfile.displayName ?? '').trim();
+		const resolvedDisplayName = displayName || userProfile.email || 'Member';
+
+		const cleanedScores = cumulativeScores
+			.map((item) => {
+				const cleaned = {};
+				if (Number(item.score.reps) > 0) cleaned.reps = Number(item.score.reps);
+				if (Number(item.score.weight) > 0) cleaned.weight = Number(item.score.weight);
+				if (Number(item.score.cals) > 0) cleaned.cals = Number(item.score.cals);
+				const formattedDistance = formatDistance(item.score.dist);
+				if (formattedDistance) cleaned.dist = formattedDistance;
+				if (item.score.notes && String(item.score.notes).trim()) {
+					cleaned.notes = String(item.score.notes).trim();
+				}
+				if (Array.isArray(item.score.selections) && item.score.selections.length) {
+					cleaned.selections = item.score.selections;
+				}
+
+				if (!Object.keys(cleaned).length) {
+					return null;
+				}
+
+				const stationName =
+					typeof item.stationName === 'string' && item.stationName.trim()
+						? item.stationName.trim()
+						: null;
+				const category =
+					typeof item.category === 'string' && item.category.trim() ? item.category.trim() : null;
+
+				return {
+					...(stationName !== null ? { stationName } : {}),
+					...(category !== null ? { category } : {}),
+					score: cleaned
+				};
+			})
+			.filter(Boolean);
+
+		const completionRecords = [completionFinisherEntry, completionSummaryEntry]
+			.map((entry) => {
+				if (!entry || !entry.score) return null;
+				const cleaned = {};
+				if (Number(entry.score.reps) > 0) cleaned.reps = Number(entry.score.reps);
+				if (Number(entry.score.cals) > 0) cleaned.cals = Number(entry.score.cals);
+				if (entry.score.notes && String(entry.score.notes).trim()) {
+					cleaned.notes = String(entry.score.notes).trim();
+				}
+				if (Array.isArray(entry.score.selections) && entry.score.selections.length) {
+					cleaned.selections = entry.score.selections;
+				}
+
+				if (!Object.keys(cleaned).length) {
+					return null;
+				}
+
+				const stationName =
+					typeof entry.stationName === 'string' && entry.stationName.trim()
+						? entry.stationName.trim()
+						: null;
+				const category =
+					typeof entry.category === 'string' && entry.category.trim()
+						? entry.category.trim()
+						: null;
+
+				return {
+					...(stationName !== null ? { stationName } : {}),
+					...(category !== null ? { category } : {}),
+					score: cleaned
+				};
+			})
+			.filter(Boolean);
+
+		const combinedScores = [...cleanedScores, ...completionRecords];
+
+		if (!combinedScores.length) {
+			finalSaveStatus = 'error';
+			finalSaveMessage = 'Log at least one score before uploading your workout.';
+			return;
+		}
+
+		try {
+			await addDoc(collection(db, 'scores'), {
+				userId: $user.uid,
+				displayName: resolvedDisplayName,
+				email: userProfile.email ?? '',
+				workoutId: workout.id,
+				workoutTitle: workout.title,
+				sessionId: session.id,
+				sessionDate: session.sessionDate ?? null,
+				totalTimeMinutes: totalTime,
+				date: serverTimestamp(),
+				exerciseScores: combinedScores
+			});
+
+			const attendanceRef = doc(db, 'attendance', `${session.id}_${$user.uid}`);
+			const sessionAttendanceId = `${session.id}_${$user.uid}`;
+
+			const buildAttendancePayload = () => {
+				const payload = {
+					userId: $user.uid,
+					displayName: resolvedDisplayName,
+					email: userProfile.email ?? '',
+					sessionId: session.id,
+					sessionAttendanceId,
+					workoutId: workout.id,
+					workoutTitle: workout.title,
+					sessionDate: session.sessionDate ?? null,
+					date: serverTimestamp()
+				};
+
+				if (session?.creatorId) {
+					payload.creatorId = session.creatorId;
+				}
+
+				return payload;
+			};
+
+			const attendanceWrite = (async () => {
+				try {
+					await setDoc(attendanceRef, buildAttendancePayload(), { merge: true });
+				} catch (primaryError) {
+					console.warn(
+						'Primary attendance write failed, attempting fallback record.',
+						primaryError
+					);
+					try {
+						await addDoc(collection(db, 'attendance'), {
+							...buildAttendancePayload()
+						});
+					} catch (fallbackError) {
+						console.error('Fallback attendance write failed:', fallbackError);
+						throw fallbackError;
+					}
+				}
+			})();
+
+			const sessionRef = doc(db, 'sessions', session.id);
+			const sessionUpdate = updateDoc(sessionRef, {
+				attendance: arrayUnion({
+					userId: $user.uid,
+					displayName: resolvedDisplayName,
+					email: userProfile.email ?? ''
+				})
+			});
+
+			const ratingValue = Number(feedbackRating);
+			const trimmedComment = feedbackComment.trim();
+			const hasRating = Number.isFinite(ratingValue) && ratingValue > 0;
+			const shouldRecordFeedback = hasRating || trimmedComment.length;
+
+			const writes = [
+				{ type: 'attendance-record', promise: attendanceWrite },
+				{ type: 'session-attendance', promise: sessionUpdate }
+			];
+
+			if (shouldRecordFeedback) {
+				const feedbackPayload = {
+					rating: hasRating ? ratingValue : null,
+					comment: trimmedComment,
+					createdAt: serverTimestamp()
+				};
+
+				const recordFeedback = async () => {
+					try {
+						await addDoc(collection(db, 'sessions', session.id, 'feedback'), feedbackPayload);
+					} catch (primaryError) {
+						console.warn(
+							'Primary feedback write failed, attempting fallback collection.',
+							primaryError
+						);
+						try {
+							await addDoc(collection(db, 'sessionFeedback'), {
+								...feedbackPayload,
+								sessionId: session.id,
+								workoutId: workout.id,
+								workoutTitle: workout.title,
+								userId: $user.uid,
+								displayName: resolvedDisplayName
+							});
+						} catch (fallbackError) {
+							console.error('Fallback feedback write failed:', fallbackError);
+							throw fallbackError;
+						}
+					}
+				};
+
+				writes.push({ type: 'feedback', promise: recordFeedback() });
+			}
+
+			const writeResults = await Promise.allSettled(writes.map((entry) => entry.promise));
+			const failureTypes = new Set();
+
+			writeResults.forEach((result, index) => {
+				if (result.status === 'rejected') {
+					const { type } = writes[index];
+					failureTypes.add(type);
+					if (type === 'session-attendance') {
+						console.warn('Session attendance array update failed:', result.reason);
+					} else {
+						console.error('Follow-up write failed:', result.reason);
+					}
+				}
+			});
+
+			hasSavedFinalScore = true;
+
+			const attendanceFailed = failureTypes.has('attendance-record');
+			const sessionAttendanceFailed = failureTypes.has('session-attendance');
+			const feedbackFailed = failureTypes.has('feedback');
+
+			if (attendanceFailed) {
+				finalSaveStatus = 'warning';
+				finalSaveMessage =
+					'Workout saved, but we could not record your attendance. Please let your coach know so they can update it.';
+			} else if (feedbackFailed) {
+				finalSaveStatus = 'warning';
+				finalSaveMessage =
+					'Workout saved, but we could not record your feedback. Please try again later or let your coach know.';
+			} else {
+				finalSaveStatus = 'success';
+				finalSaveMessage = 'Workout uploaded to your dashboard.';
+
+				if (sessionAttendanceFailed) {
+					console.info(
+						'Attendance fallback will rely on standalone attendance records for this session.'
+					);
+				}
+			}
+		} catch (error) {
+			console.error('Error saving score:', error);
+			finalSaveStatus = 'error';
+			finalSaveMessage = 'Failed to upload workout. Please try again.';
+		} finally {
+			feedbackRating = 0;
+			feedbackComment = '';
+		}
+	}
+
+	$: totalStations = workout.exercises?.length ?? 0;
+
+	$: if (
+		myScoreRef &&
+		userProfile.displayName &&
+		workout.mode !== 'Partner' &&
+		!hasJoinedRoster &&
+		rosterStatus === 'idle'
+	) {
+		wantsPartnerPairing = true;
+		joinStationRoster().catch((err) => console.error('Auto-join failed:', err));
+	}
+
+	$: if (
+		myScoreRef &&
+		userProfile.displayName &&
+		workout.mode === 'Partner' &&
+		wantsPartnerPairing &&
+		!hasJoinedRoster &&
+		rosterStatus === 'idle'
+	) {
+		joinStationRoster({ trainingSolo: false }).catch((err) =>
+			console.error('Auto-join partner failed:', err)
+		);
+	}
+
+	$: if (
+		workout.mode === 'Partner' &&
+		!wantsPartnerPairing &&
+		hasJoinedRoster &&
+		rosterStatus === 'idle' &&
+		!isTrainingSolo
+	) {
+		void leaveStationRoster();
+	}
+
+	$: if (userProfile.displayName && hasJoinedRoster) {
+		const assignments = normaliseStationAssignments(
+			liveState.stationAssignments ?? session.stationAssignments,
+			workout.exercises.length
+		);
+		if (assignments.length && liveState.movesCompleted !== undefined) {
+			const uppercaseName = userProfile.displayName?.toUpperCase();
+			let startingIndex = -1;
+			let startingRoster = [];
+			assignments.forEach((roster, index) => {
+				if (roster.includes(uppercaseName)) {
+					startingIndex = index;
+					startingRoster = roster;
+				}
+			});
+
+			if (startingIndex !== -1) {
+				const total = workout.exercises.length;
+				myPartnerSlot = startingRoster.indexOf(uppercaseName);
+				myCurrentStationIndex = (startingIndex + liveState.movesCompleted) % total;
+				myNextStationIndex = (myCurrentStationIndex + 1) % total;
+			} else {
+				myPartnerSlot = -1;
+				myCurrentStationIndex = -1;
+				myNextStationIndex = -1;
+			}
+		}
+	} else {
+		myPartnerSlot = -1;
+		myCurrentStationIndex = -1;
+		myNextStationIndex = -1;
+	}
+
+	$: if (hasJoinedRoster && myCurrentStationIndex !== previousStationIndex) {
+		if (previousStationIndex !== -1) {
+			void commitStationScore(previousStationIndex, { auto: true });
+		}
+		previousStationIndex = myCurrentStationIndex;
+		if (myCurrentStationIndex !== lastSavedStationIndex) {
+			lastSaveMessage = '';
+			lastSaveType = 'idle';
+		}
+	}
+
+	$: if (liveState.isComplete && !previousCompletionState) {
+		previousCompletionState = true;
+		if (myCurrentStationIndex !== -1) {
+			void commitStationScore(myCurrentStationIndex, { auto: true });
+		}
+	} else if (!liveState.isComplete && previousCompletionState) {
+		previousCompletionState = false;
+	}
+
+	$: myStationData = myCurrentStationIndex !== -1 ? workout.exercises[myCurrentStationIndex] : null;
+	$: nextStationData = myNextStationIndex !== -1 ? workout.exercises[myNextStationIndex] : null;
+	$: nextStationCategory = nextStationData
+		? normaliseCategory(
+				workout.mode === 'Partner'
+					? nextStationData.p1?.category || nextStationData.category
+					: nextStationData.category,
+				DEFAULT_CATEGORY
+			)
+		: '';
+	$: intervalDuration =
+		liveState?.duration || liveState?.timing?.work || session?.timing?.work || null;
+	$: hasPendingForCurrent =
+		myCurrentStationIndex >= 0 && pendingStations.has(myCurrentStationIndex);
+	$: chipperSteps = isChipperMode ? (workout.chipper?.steps ?? []) : [];
+	$: chipperGroups = isChipperMode ? buildChipperGroups(chipperSteps) : [];
+	$: chipperFinisher = isChipperMode ? (workout.chipper?.finisher ?? null) : null;
+	$: chipperFinisherName =
+		chipperFinisher?.name && chipperFinisher.name.trim()
+			? chipperFinisher.name.trim()
+			: 'Chipper Finisher';
+	$: chipperFinisherCategory = normaliseCategory(chipperFinisher?.category, 'Cardio Machine');
+	$: finisherMetric = isChipperMode ? getFinisherMetricForCategory(chipperFinisherCategory) : null;
+	$: if (isChipperMode && chipperSteps.length) {
+		const names = chipperSteps.map((step) => step?.name ?? '');
+		if (!completionForm.progressExercise || !names.includes(completionForm.progressExercise)) {
+			completionForm = { ...completionForm, progressExercise: names[0] ?? '' };
+		}
+	}
+
+	$: currentP1Task = myStationData?.p1?.task ? String(myStationData.p1.task).trim() : '';
+	$: currentP2Task = myStationData?.p2?.task ? String(myStationData.p2.task).trim() : '';
+	$: stationCategory = myStationData
+		? normaliseCategory(myStationData.category, DEFAULT_CATEGORY)
+		: DEFAULT_CATEGORY;
+	$: primaryTaskDetails = myStationData
+		? {
+				name: currentP1Task || myStationData.name || '',
+				category: normaliseCategory(myStationData.p1?.category, stationCategory)
+			}
+		: { name: '', category: DEFAULT_CATEGORY };
+	$: secondaryTaskDetails = myStationData
+		? {
+				name: currentP2Task || primaryTaskDetails.name || myStationData.name || '',
+				category: normaliseCategory(myStationData.p2?.category, primaryTaskDetails.category)
+			}
+		: { name: '', category: DEFAULT_CATEGORY };
+	$: {
+		if (myStationData && Array.isArray(myStationData.equipment)) {
+			const cleaned = myStationData.equipment
+				.map((item) => (typeof item === 'string' ? item.trim() : ''))
+				.filter((item) => item.length > 0);
+			equipmentOptions = Array.from(new Set(cleaned));
+		} else {
+			equipmentOptions = [];
+		}
+	}
+	$: selectedEquipment =
+		myCurrentStationIndex >= 0 && currentEntries[myCurrentStationIndex]
+			? String(currentEntries[myCurrentStationIndex].score.selection || '')
+			: '';
+	$: equipmentHistory =
+		myCurrentStationIndex >= 0 &&
+		Array.isArray(cumulativeScores[myCurrentStationIndex]?.score?.selections)
+			? Array.from(
+					new Set(
+						cumulativeScores[myCurrentStationIndex].score.selections
+							.map((item) => (typeof item === 'string' ? item.trim() : ''))
+							.filter(Boolean)
+					)
+				)
+			: [];
+	$: isRestPhase = liveState?.phaseType === 'rest';
+	$: if (workout.mode === 'Partner') {
+		if (myPartnerSlot === 0) {
+			myPartnerRole = 'Partner A';
+		} else if (myPartnerSlot === 1) {
+			myPartnerRole = 'Partner B';
+		} else if (myPartnerSlot >= 0) {
+			myPartnerRole = `Partner ${myPartnerSlot + 1}`;
+		} else {
+			myPartnerRole = '';
+		}
+	} else {
+		myPartnerRole = '';
+	}
+	$: {
+		if (!myStationData) {
+			soloPrimaryTask = '';
+			soloSecondaryTask = '';
+			myActiveTaskLabel = '';
+			activeTask = { name: '', category: DEFAULT_CATEGORY };
+			upcomingTask = null;
+			metricCategory = DEFAULT_CATEGORY;
+		} else {
+			const fallbackName = myStationData.name || '';
+			const primaryName = primaryTaskDetails.name || fallbackName;
+			const secondaryName = secondaryTaskDetails.name || primaryName;
+			const hasDistinctSecondary = Boolean(
+				secondaryTaskDetails.name && secondaryName !== primaryName
+			);
+			const isSecondWorkBlock = liveState?.phaseIndex === 2;
+
+			soloPrimaryTask = primaryName;
+			soloSecondaryTask = hasDistinctSecondary ? secondaryName : '';
+
+			let nextActive = { ...primaryTaskDetails, name: primaryName };
+			let nextUpcoming = hasDistinctSecondary
+				? { ...secondaryTaskDetails, name: secondaryName }
+				: null;
+
+			if (workout.mode === 'Partner') {
+				if (isTrainingSolo || myPartnerSlot === 0) {
+					if (isSecondWorkBlock && hasDistinctSecondary) {
+						nextActive = { ...secondaryTaskDetails, name: secondaryName };
+						nextUpcoming = null;
+					}
+				} else if (myPartnerSlot === 1) {
+					if (!isSecondWorkBlock && hasDistinctSecondary) {
+						nextActive = { ...secondaryTaskDetails, name: secondaryName };
+						nextUpcoming = { ...primaryTaskDetails, name: primaryName };
+					} else {
+						nextActive = { ...primaryTaskDetails, name: primaryName };
+						nextUpcoming = null;
+					}
+				} else if (myPartnerSlot >= 0) {
+					nextActive = { ...primaryTaskDetails, name: primaryName };
+					nextUpcoming = hasDistinctSecondary
+						? { ...secondaryTaskDetails, name: secondaryName }
+						: null;
+				}
+			} else if (!hasDistinctSecondary) {
+				nextUpcoming = null;
+			}
+
+			activeTask = nextActive;
+			upcomingTask = nextUpcoming;
+			myActiveTaskLabel = activeTask.name || fallbackName || primaryName;
+			metricCategory = activeTask.category || stationCategory || DEFAULT_CATEGORY;
+		}
+	}
+	$: metricLabel = myStationData ? getMetricLabelForCategory(metricCategory) : '';
+	$: hasSessionStarted =
+		Number.isFinite(liveState?.phaseIndex) && liveState.phaseIndex >= 0 && !liveState.isComplete;
+	$: showPairingControls = workout.mode === 'Partner' && !hasSessionStarted;
+	$: {
+		if (rosterStatus === 'joining') {
+			partnerStatusText = 'Adding you to the partner rotation...';
+		} else if (rosterStatus === 'leaving') {
+			partnerStatusText = 'Updating your selection...';
+		} else if (isTrainingSolo) {
+			if (hasJoinedRoster) {
+				partnerStatusText = "You're locked in to train solo for this partner session.";
+			} else if (rosterError) {
+				partnerStatusText = "We're unable to add you just yet. Please review the message below.";
+			} else {
+				partnerStatusText = "We'll load your solo station as soon as it's assigned.";
+			}
+		} else if (wantsPartnerPairing) {
+			if (hasJoinedRoster) {
+				partnerStatusText = "You're set to rotate with a partner.";
+			} else if (rosterError) {
+				partnerStatusText = "We're unable to add you just yet. Please review the message below.";
+			} else {
+				partnerStatusText = "We'll add you as soon as there's an open station.";
+			}
+		} else {
+			partnerStatusText = "You're logged to train solo for this session.";
+		}
+	}
+
+	function formatTime(s) {
+		const secs = Math.max(0, Math.ceil(s));
+		return (
+			String(Math.floor(secs / 60)).padStart(2, '0') + ':' + String(secs % 60).padStart(2, '0')
+		);
+	}
 </script>
 
-
 <div class="tracker-container">
-        <div class="tracker-layout" class:chipper={isChipperMode}>
-                {#if isChipperMode}
-                        <section class="timer-card" aria-live="polite">
-                                <header class="timer-header">
-                                        <span class="phase-label">{liveState.phase}</span>
-                                </header>
-                                <div class="time-display">{formatTime(liveState.remaining)}</div>
-                                {#if liveState.currentStationMeta?.category || intervalDuration}
-                                        <div class="phase-meta">
-                                                {#if liveState.currentStationMeta?.category}
-                                                        <span class="phase-chip">{liveState.currentStationMeta.category}</span>
-                                                {/if}
-                                                {#if intervalDuration}
-                                                        <span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
-                                                {/if}
-                                        </div>
-                                {/if}
-                        </section>
-                {/if}
+	<div class="tracker-shell">
+		<div class="tracker-layout" class:chipper={isChipperMode}>
+			{#if isChipperMode}
+				<section class="timer-card" aria-live="polite">
+					<header class="timer-header">
+						<span class="phase-label">{liveState.phase}</span>
+					</header>
+					<div class="time-display">{formatTime(liveState.remaining)}</div>
+					{#if liveState.currentStationMeta?.category || intervalDuration}
+						<div class="phase-meta">
+							{#if liveState.currentStationMeta?.category}
+								<span class="phase-chip">{liveState.currentStationMeta.category}</span>
+							{/if}
+							{#if intervalDuration}
+								<span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
+							{/if}
+						</div>
+					{/if}
+				</section>
+			{/if}
 
+			<div class={isChipperMode ? 'chipper-content-grid' : 'standard-content-grid'}>
+				{#if isChipperMode}
+					<section class="chipper-overview" aria-labelledby="chipper-title">
+						<div class="chipper-header">
+							<h2 id="chipper-title">Chipper flow</h2>
+							<p>Work from the top of the pyramid, then finish strong when the clock ends.</p>
+						</div>
 
-                <div class={isChipperMode ? 'chipper-content-grid' : 'standard-content-grid'}>
-                        {#if isChipperMode}
-                                <section class="chipper-overview" aria-labelledby="chipper-title">
-                                        <div class="chipper-header">
-                                                <h2 id="chipper-title">Chipper flow</h2>
-                                                <p>Work from the top of the pyramid, then finish strong when the clock ends.</p>
-                                        </div>
+						{#if chipperGroups.length}
+							<div class="chipper-pyramid">
+								{#each chipperGroups as group, groupIndex}
+									<div class="chipper-tier" data-group={groupIndex}>
+										<div class="tier-reps">
+											{typeof group.reps === 'number' ? `${group.reps}` : group.reps}
+										</div>
+										<ul class="tier-movements">
+											{#each group.items as item}
+												<li class:completed={completedChipperSteps.has(item.order)}>
+													<label class="tier-item">
+														<span class="tier-order">#{item.order}</span>
+														<span class="tier-name">{item.name}</span>
+														{#if item.category}
+															<span class="tier-category">{item.category}</span>
+														{/if}
+														<input
+															type="checkbox"
+															class="tier-checkbox"
+															checked={completedChipperSteps.has(item.order)}
+															on:change={() => toggleChipperStepCompletion(item.order)}
+														/>
+													</label>
+												</li>
+											{/each}
+										</ul>
+									</div>
+								{/each}
+							</div>
+						{:else}
+							<p class="chipper-empty">No chipper movements configured yet.</p>
+						{/if}
 
-                                        {#if chipperGroups.length}
-                                                <div class="chipper-pyramid">
-                                                        {#each chipperGroups as group, groupIndex}
-                                                                <div class="chipper-tier" data-group={groupIndex}>
-                                                                        <div class="tier-reps">{typeof group.reps === 'number' ? `${group.reps}` : group.reps}</div>
-                                                                        <ul class="tier-movements">
-                                                                                {#each group.items as item}
-                                                                                        <li class:completed={completedChipperSteps.has(item.order)}>
-                                                                                                <label class="tier-item">
-                                                                                                        <span class="tier-order">#{item.order}</span>
-                                                                                                        <span class="tier-name">{item.name}</span>
-                                                                                                        {#if item.category}
-                                                                                                                <span class="tier-category">{item.category}</span>
-                                                                                                        {/if}
-                                                                                                        <input
-                                                                                                                type="checkbox"
-                                                                                                                class="tier-checkbox"
-                                                                                                                checked={completedChipperSteps.has(item.order)}
-                                                                                                                on:change={() => toggleChipperStepCompletion(item.order)}
-                                                                                                        />
-                                                                                                </label>
-                                                                                        </li>
-                                                                                {/each}
-                                                                        </ul>
-                                                                </div>
-                                                        {/each}
-                                                </div>
-                                        {:else}
-                                                <p class="chipper-empty">No chipper movements configured yet.</p>
-                                        {/if}
+						{#if chipperFinisher?.name}
+							<div class="chipper-finisher-card">
+								<span class="finisher-label">Finisher</span>
+								<div class="finisher-details">
+									<strong>{chipperFinisher.name}</strong>
+									<span>{chipperFinisher.description || 'Max effort until the timer ends.'}</span>
+								</div>
+							</div>
+						{/if}
+					</section>
+				{:else if isAmrapType}
+					<section class="amrap-simple-grid" aria-labelledby="amrap-simple-title">
+						<div class="amrap-time-card">
+							<p class="eyebrow">Time remaining</p>
+							<p class="amrap-clock">{formatTime(liveState.remaining)}</p>
+							<div class="phase-meta">
+								<span class="phase-chip">{liveState.phase}</span>
+								{#if intervalDuration}
+									<span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
+								{/if}
+							</div>
+						</div>
+						<div class="amrap-move-card">
+							<p class="eyebrow">AMRAP Flow</p>
+							<h2 id="amrap-simple-title">Complete these on repeat</h2>
+							{#if workout.exercises?.length}
+								<ol class="amrap-move-list">
+									{#each workout.exercises as exercise, index}
+										<li>
+											<span class="amrap-order">{index + 1}</span>
+											<div class="amrap-move-details">
+												<strong>{exercise.name}</strong>
+												{#if exercise.category}
+													<span class="task-chip subtle">{exercise.category}</span>
+												{/if}
+												{#if exercise.description}
+													<span class="amrap-desc">{exercise.description}</span>
+												{/if}
+											</div>
+										</li>
+									{/each}
+								</ol>
+							{:else}
+								<p class="rest-callout">
+									Add movements to this AMRAP in the admin setup to see them here.
+								</p>
+							{/if}
+						</div>
+						<div class="amrap-round-card">
+							<p class="eyebrow">Rounds completed</p>
+							<div class="amrap-round-controls">
+								<button
+									type="button"
+									class="round-step"
+									on:click={() => adjustAmrapRounds(-1)}
+									disabled={amrapRoundCount === 0}
+									aria-label="Decrease rounds"
+								>
+									−
+								</button>
+								<div class="amrap-round-display">{amrapRoundCount}</div>
+								<button
+									type="button"
+									class="round-step"
+									on:click={() => adjustAmrapRounds(1)}
+									aria-label="Increase rounds"
+								>
+									+
+								</button>
+							</div>
+							<label class="extra-reps-field">
+								<span>Extra reps (optional)</span>
+								<input
+									type="number"
+									min="0"
+									inputmode="numeric"
+									value={amrapExtraReps}
+									on:input={handleAmrapRepsInput}
+									aria-label="Extra reps after last full round"
+								/>
+							</label>
+							<p class="round-hint">
+								Saved straight to your benchmark dashboard when you end the workout.
+							</p>
+						</div>
+					</section>
 
-                                        {#if chipperFinisher?.name}
-                                                <div class="chipper-finisher-card">
-                                                        <span class="finisher-label">Finisher</span>
-                                                        <div class="finisher-details">
-                                                                <strong>{chipperFinisher.name}</strong>
-                                                                <span>{chipperFinisher.description || 'Max effort until the timer ends.'}</span>
-                                                        </div>
-                                                </div>
-                                        {/if}
-                                </section>
-                        {:else if isAmrapType}
-                                <section class="amrap-simple-grid" aria-labelledby="amrap-simple-title">
-                                        <div class="amrap-time-card">
-                                                <p class="eyebrow">Time remaining</p>
-                                                <p class="amrap-clock">{formatTime(liveState.remaining)}</p>
-                                                <div class="phase-meta">
-                                                        <span class="phase-chip">{liveState.phase}</span>
-                                                        {#if intervalDuration}
-                                                                <span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
-                                                        {/if}
-                                                </div>
-                                        </div>
-                                        <div class="amrap-move-card">
-                                                <p class="eyebrow">AMRAP Flow</p>
-                                                <h2 id="amrap-simple-title">Complete these on repeat</h2>
-                                                {#if workout.exercises?.length}
-                                                        <ol class="amrap-move-list">
-                                                                {#each workout.exercises as exercise, index}
-                                                                        <li>
-                                                                                <span class="amrap-order">{index + 1}</span>
-                                                                                <div class="amrap-move-details">
-                                                                                        <strong>{exercise.name}</strong>
-                                                                                        {#if exercise.category}
-                                                                                                <span class="task-chip subtle">{exercise.category}</span>
-                                                                                        {/if}
-                                                                                        {#if exercise.description}
-                                                                                                <span class="amrap-desc">{exercise.description}</span>
-                                                                                        {/if}
-                                                                                </div>
-                                                                        </li>
-                                                                {/each}
-                                                        </ol>
-                                                {:else}
-                                                        <p class="rest-callout">Add movements to this AMRAP in the admin setup to see them here.</p>
-                                                {/if}
-                                        </div>
-                                        <div class="amrap-round-card">
-                                                <p class="eyebrow">Rounds completed</p>
-                                                <div class="amrap-round-controls">
-                                                        <button type="button" class="round-step" on:click={() => adjustAmrapRounds(-1)} disabled={amrapRoundCount === 0} aria-label="Decrease rounds">
-                                                                −
-                                                        </button>
-                                                        <div class="amrap-round-display">{amrapRoundCount}</div>
-                                                        <button type="button" class="round-step" on:click={() => adjustAmrapRounds(1)} aria-label="Increase rounds">
-                                                                +
-                                                        </button>
-                                                </div>
-                                                <label class="extra-reps-field">
-                                                        <span>Extra reps (optional)</span>
-                                                        <input
-                                                                type="number"
-                                                                min="0"
-                                                                inputmode="numeric"
-                                                                value={amrapExtraReps}
-                                                                on:input={handleAmrapRepsInput}
-                                                                aria-label="Extra reps after last full round"
-                                                        />
-                                                </label>
-                                                <p class="round-hint">Saved straight to your benchmark dashboard when you end the workout.</p>
-                                        </div>
-                                </section>
+					{#if liveState.isComplete}
+						<section class="post-workout-card" aria-live="polite">
+							<h2>Workout complete</h2>
+							<p>Upload your results to save them to your dashboard.</p>
+							{#if requiresCompletionLog}
+								{#if completionFinisherEntry || completionSummaryEntry}
+									<div class="completion-summary">
+										{#if completionFinisherEntry?.score?.cals}
+											<div class="summary-line">
+												<span>Finisher</span><strong
+													>{completionFinisherEntry.score.cals} cal{completionFinisherEntry.score
+														.cals === 1
+														? ''
+														: 's'}</strong
+												>
+											</div>
+										{:else if completionFinisherEntry?.score?.reps}
+											<div class="summary-line">
+												<span>Finisher</span><strong
+													>{completionFinisherEntry.score.reps} rep{completionFinisherEntry.score
+														.reps === 1
+														? ''
+														: 's'}</strong
+												>
+											</div>
+										{/if}
+										{#if completionSummaryEntry?.score?.notes}
+											<div class="summary-line">
+												<span>Progress</span><strong>{completionSummaryEntry.score.notes}</strong>
+											</div>
+										{/if}
+										<button type="button" class="btn btn-outline" on:click={openCompletionModal}
+											>Edit result</button
+										>
+									</div>
+								{:else}
+									<p class="completion-hint">Log your finish to wrap up this session.</p>
+									<button type="button" class="btn ghost" on:click={openCompletionModal}
+										>Log finish</button
+									>
+								{/if}
+							{/if}
+							<button
+								class="btn btn-primary"
+								on:click={startUpload}
+								disabled={finalSaveStatus === 'saving' || hasSavedFinalScore}
+							>
+								{hasSavedFinalScore
+									? 'Uploaded'
+									: finalSaveStatus === 'saving'
+										? 'Uploading...'
+										: 'End workout'}
+							</button>
+							{#if finalSaveMessage}
+								<p class={`status ${finalSaveStatus}`}>{finalSaveMessage}</p>
+							{/if}
+						</section>
+					{/if}
+				{:else}
+					<aside class="session-sidebar">
+						<section class="timer-card" aria-live="polite">
+							<header class="timer-header">
+								<span class="phase-label">{liveState.phase}</span>
+							</header>
+							<div class="time-display">{formatTime(liveState.remaining)}</div>
+							{#if liveState.currentStationMeta?.category || intervalDuration}
+								<div class="phase-meta">
+									{#if liveState.currentStationMeta?.category}
+										<span class="phase-chip">{liveState.currentStationMeta.category}</span>
+									{/if}
+									{#if intervalDuration}
+										<span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
+									{/if}
+								</div>
+							{/if}
+						</section>
 
-                                {#if liveState.isComplete}
-                                        <section class="post-workout-card" aria-live="polite">
-                                                <h2>Workout complete</h2>
-                                                <p>Upload your results to save them to your dashboard.</p>
-                                                {#if requiresCompletionLog}
-                                                        {#if completionFinisherEntry || completionSummaryEntry}
-                                                                <div class="completion-summary">
-                                                                        {#if completionFinisherEntry?.score?.cals}
-                                                                                <div class="summary-line"><span>Finisher</span><strong>{completionFinisherEntry.score.cals} cal{completionFinisherEntry.score.cals === 1 ? '' : 's'}</strong></div>
-                                                                        {:else if completionFinisherEntry?.score?.reps}
-                                                                                <div class="summary-line"><span>Finisher</span><strong>{completionFinisherEntry.score.reps} rep{completionFinisherEntry.score.reps === 1 ? '' : 's'}</strong></div>
-                                                                        {/if}
-                                                                        {#if completionSummaryEntry?.score?.notes}
-                                                                                <div class="summary-line"><span>Progress</span><strong>{completionSummaryEntry.score.notes}</strong></div>
-                                                                        {/if}
-                                                                        <button type="button" class="btn btn-outline" on:click={openCompletionModal}>Edit result</button>
-                                                                </div>
-                                                        {:else}
-                                                                <p class="completion-hint">Log your finish to wrap up this session.</p>
-                                                                <button type="button" class="btn ghost" on:click={openCompletionModal}>Log finish</button>
-                                                        {/if}
-                                                {/if}
-                                                <button
-                                                        class="btn btn-primary"
-                                                        on:click={startUpload}
-                                                        disabled={finalSaveStatus === 'saving' || hasSavedFinalScore}
-                                                >
-                                                        {hasSavedFinalScore ? 'Uploaded' : finalSaveStatus === 'saving' ? 'Uploading...' : 'End workout'}
-                                                </button>
-                                                {#if finalSaveMessage}
-                                                        <p class={`status ${finalSaveStatus}`}>{finalSaveMessage}</p>
-                                                {/if}
-                                        </section>
-                                {/if}
-                        {:else}
-                                <aside class="session-sidebar">
-                                        <section class="timer-card" aria-live="polite">
-                                                <header class="timer-header">
-                                                        <span class="phase-label">{liveState.phase}</span>
-                                                </header>
-                                                <div class="time-display">{formatTime(liveState.remaining)}</div>
-                                                {#if liveState.currentStationMeta?.category || intervalDuration}
-                                                        <div class="phase-meta">
-                                                                {#if liveState.currentStationMeta?.category}
-                                                                        <span class="phase-chip">{liveState.currentStationMeta.category}</span>
-                                                                {/if}
-                                                                {#if intervalDuration}
-                                                                        <span class="phase-chip">Interval: {Math.round(intervalDuration)}s</span>
-                                                                {/if}
-                                                        </div>
-                                                {/if}
-                                        </section>
+						{#if myStationData}
+							<section class="station-overview" aria-labelledby="station-now-title">
+								<div class="station-heading">
+									<span class="station-eyebrow">Now</span>
+									<h2 id="station-now-title">{myStationData.name}</h2>
+									<p class="station-meta">
+										Station {myCurrentStationIndex + 1}
+										{#if stationCategory}
+											<span aria-hidden="true">·</span>
+											{stationCategory}
+										{/if}
+									</p>
+								</div>
+								{#if isRestPhase && myStationData}
+									<p class="rest-callout">
+										Recovery minute — log your score for <strong>{myStationData.name}</strong>
+										{#if nextStationData}
+											and prepare for <strong>{nextStationData.name}</strong>.
+										{:else}.
+										{/if}
+									</p>
+								{/if}
+								{#if workout.mode === 'Partner'}
+									{#if isTrainingSolo}
+										{#if soloPrimaryTask}
+											<p class="start-callout">
+												Training solo? Start on <strong>{soloPrimaryTask}</strong>
+												{#if soloSecondaryTask}
+													, then transition to <strong>{soloSecondaryTask}</strong>.
+												{:else}.
+												{/if}
+											</p>
+										{/if}
+									{:else if myPartnerSlot !== -1 && myActiveTaskLabel}
+										<p class="start-callout">
+											{#if myPartnerRole}<span class="start-role">{myPartnerRole}</span>{/if}
+											Start on <strong>{myActiveTaskLabel}</strong>.
+										</p>
+									{/if}
+								{/if}
+								{#if workout.mode === 'Partner' && upcomingTask && !isTrainingSolo && myPartnerSlot !== -1 && upcomingTask.name !== myActiveTaskLabel}
+									<p class="upcoming-note">Next interval: <strong>{upcomingTask.name}</strong></p>
+								{/if}
+								<div class="task-list">
+									<div class="task-line">
+										<span class="task-label">Primary</span>
+										<span class="task-name">{primaryTaskDetails.name}</span>
+									</div>
+									{#if secondaryTaskDetails.name && secondaryTaskDetails.name !== primaryTaskDetails.name}
+										<div class="task-line">
+											<span class="task-label secondary">Secondary</span>
+											<span class="task-name">{secondaryTaskDetails.name}</span>
+										</div>
+									{/if}
+								</div>
+								{#if equipmentOptions.length}
+									<div class="equipment-options-list">
+										<span class="equipment-options-label">Options</span>
+										<span class="equipment-options-values">{equipmentOptions.join(' • ')}</span>
+									</div>
+								{/if}
+								{#if myNextStationIndex !== -1}
+									<div class="station-next">
+										<h3>Next</h3>
+										<p>Station {myNextStationIndex + 1}</p>
+										{#if nextStationCategory}
+											<span class="station-chip">{nextStationCategory}</span>
+										{/if}
+									</div>
+								{/if}
+							</section>
+						{:else}
+							<section class="workout-overview" aria-labelledby="workout-overview-title">
+								<h2 id="workout-overview-title">Workout flow</h2>
+								<ul>
+									{#each workout.exercises as exercise, index}
+										<li>
+											<span class="workout-index">{index + 1}</span>
+											<div class="workout-info">
+												<strong>{exercise.name}</strong>
+												{#if exercise.description}
+													<span>{exercise.description}</span>
+												{/if}
+											</div>
+										</li>
+									{/each}
+								</ul>
+							</section>
+						{/if}
+					</aside>
 
-                                        {#if myStationData}
-                                                <section class="station-overview" aria-labelledby="station-now-title">
-                                                        <div class="station-heading">
-                                                                <span class="station-eyebrow">Now</span>
-                                                                <h2 id="station-now-title">{myStationData.name}</h2>
-                                                                <p class="station-meta">
-                                                                        Station {myCurrentStationIndex + 1}
-                                                                        {#if stationCategory}
-                                                                                <span aria-hidden="true">·</span>
-                                                                                {stationCategory}
-                                                                        {/if}
-                                                                </p>
-                                                        </div>
-                                                        {#if isRestPhase && myStationData}
-                                                                <p class="rest-callout">
-                                                                        Recovery minute — log your score for <strong>{myStationData.name}</strong>
-                                                                        {#if nextStationData}
-                                                                                and prepare for <strong>{nextStationData.name}</strong>.
-                                                                        {:else}.
-                                                                        {/if}
-                                                                </p>
-                                                        {/if}
-                                                        {#if workout.mode === 'Partner'}
-                                                                {#if isTrainingSolo}
-                                                                        {#if soloPrimaryTask}
-                                                                                <p class="start-callout">
-                                                                                        Training solo? Start on <strong>{soloPrimaryTask}</strong>
-                                                                                        {#if soloSecondaryTask}
-                                                                                                , then transition to <strong>{soloSecondaryTask}</strong>.
-                                                                                        {:else}.
-                                                                                        {/if}
-                                                                                </p>
-                                                                        {/if}
-                                                                {:else if myPartnerSlot !== -1 && myActiveTaskLabel}
-                                                                        <p class="start-callout">
-                                                                                {#if myPartnerRole}<span class="start-role">{myPartnerRole}</span>{/if}
-                                                                                Start on <strong>{myActiveTaskLabel}</strong>.
-                                                                        </p>
-                                                                {/if}
-                                                        {/if}
-                                                        {#if workout.mode === 'Partner' && upcomingTask && !isTrainingSolo && myPartnerSlot !== -1 && upcomingTask.name !== myActiveTaskLabel}
-                                                                <p class="upcoming-note">Next interval: <strong>{upcomingTask.name}</strong></p>
-                                                        {/if}
-                                                        <div class="task-list">
-                                                                <div class="task-line">
-                                                                        <span class="task-label">Primary</span>
-                                                                        <span class="task-name">{primaryTaskDetails.name}</span>
-                                                                </div>
-                                                                {#if secondaryTaskDetails.name && secondaryTaskDetails.name !== primaryTaskDetails.name}
-                                                                        <div class="task-line">
-                                                                                <span class="task-label secondary">Secondary</span>
-                                                                                <span class="task-name">{secondaryTaskDetails.name}</span>
-                                                                        </div>
-                                                                {/if}
-                                                        </div>
-                                                        {#if equipmentOptions.length}
-                                                                <div class="equipment-options-list">
-                                                                        <span class="equipment-options-label">Options</span>
-                                                                        <span class="equipment-options-values">{equipmentOptions.join(' • ')}</span>
-                                                                </div>
-                                                        {/if}
-                                                        {#if myNextStationIndex !== -1}
-                                                                <div class="station-next">
-                                                                        <h3>Next</h3>
-                                                                        <p>Station {myNextStationIndex + 1}</p>
-                                                                        {#if nextStationCategory}
-                                                                                <span class="station-chip">{nextStationCategory}</span>
-                                                                        {/if}
-                                                                </div>
-                                                        {/if}
-                                                </section>
-                                        {:else}
-                                                <section class="workout-overview" aria-labelledby="workout-overview-title">
-                                                        <h2 id="workout-overview-title">Workout flow</h2>
-                                                        <ul>
-                                                                {#each workout.exercises as exercise, index}
-                                                                        <li>
-                                                                                <span class="workout-index">{index + 1}</span>
-                                                                                <div class="workout-info">
-                                                                                        <strong>{exercise.name}</strong>
-                                                                                        {#if exercise.description}
-                                                                                                <span>{exercise.description}</span>
-                                                                                        {/if}
-                                                                                </div>
-                                                                        </li>
-                                                                {/each}
-                                                        </ul>
-                                                </section>
-                                        {/if}
-                                </aside>
+					<main class="session-main">
+						{#if workout.mode === 'Partner' && showPairingControls}
+							<section class="pairing-controls" aria-live="polite">
+								<div class="pairing-copy">
+									<h2>Partner pairing</h2>
+									<p>Choose how you'd like to train for this partner workout.</p>
+								</div>
+								<div class="pairing-actions">
+									<div class="pairing-toggle" role="radiogroup" aria-label="Partner preference">
+										<button
+											type="button"
+											class:active={isTrainingSolo}
+											class:locked={pairingLocked}
+											on:click={selectSoloMode}
+											aria-pressed={isTrainingSolo}
+											disabled={rosterStatus !== 'idle' || pairingLocked}
+										>
+											I'm riding solo
+										</button>
+										<button
+											type="button"
+											class:active={!isTrainingSolo}
+											class:locked={pairingLocked}
+											on:click={selectPartnerMode}
+											aria-pressed={!isTrainingSolo}
+											disabled={rosterStatus !== 'idle' || pairingLocked}
+										>
+											Pair me up
+										</button>
+									</div>
+									<p class="pairing-status" aria-live="polite">{partnerStatusText}</p>
+									{#if pairingLocked}
+										<p class="pairing-note">
+											Selection locked for this session. Chat with your coach if you need to change
+											it.
+										</p>
+									{/if}
+									{#if rosterError}
+										<p class="pairing-error">{rosterError}</p>
+									{/if}
+								</div>
+							</section>
+						{/if}
 
-                                <main class="session-main">
-                                        {#if workout.mode === 'Partner' && showPairingControls}
-                                                <section class="pairing-controls" aria-live="polite">
-                                                        <div class="pairing-copy">
-                                                                <h2>Partner pairing</h2>
-                                                                <p>Choose how you'd like to train for this partner workout.</p>
-                                                        </div>
-                                                        <div class="pairing-actions">
-                                                                <div class="pairing-toggle" role="radiogroup" aria-label="Partner preference">
-                                                                        <button
-                                                                                type="button"
-                                                                                class:active={isTrainingSolo}
-                                                                                class:locked={pairingLocked}
-                                                                                on:click={selectSoloMode}
-                                                                                aria-pressed={isTrainingSolo}
-                                                                                disabled={rosterStatus !== 'idle' || pairingLocked}
-                                                                        >
-                                                                                I'm riding solo
-                                                                        </button>
-                                                                        <button
-                                                                                type="button"
-                                                                                class:active={!isTrainingSolo}
-                                                                                class:locked={pairingLocked}
-                                                                                on:click={selectPartnerMode}
-                                                                                aria-pressed={!isTrainingSolo}
-                                                                                disabled={rosterStatus !== 'idle' || pairingLocked}
-                                                                        >
-                                                                                Pair me up
-                                                                        </button>
-                                                                </div>
-                                                                <p class="pairing-status" aria-live="polite">{partnerStatusText}</p>
-                                                                {#if pairingLocked}
-                                                                        <p class="pairing-note">Selection locked for this session. Chat with your coach if you need to change it.</p>
-                                                                {/if}
-                                                                {#if rosterError}
-                                                                        <p class="pairing-error">{rosterError}</p>
-                                                                {/if}
-                                                        </div>
-                                                </section>
-                                        {/if}
+						{#if myCurrentStationIndex !== -1}
+							<section class="score-card" aria-live="polite">
+								<header class="score-header">
+									<div>
+										<p class="score-eyebrow">Log your effort</p>
+										<h2>Station {myCurrentStationIndex + 1}</h2>
+										<p class="score-meta">{metricLabel}</p>
+									</div>
+									<div class="equipment-select">
+										<label>
+											<span>Equipment used</span>
+											<select
+												value={selectedEquipment}
+												on:change={(event) =>
+													setSelectedEquipment(
+														event.currentTarget?.value ?? event.target?.value ?? ''
+													)}
+											>
+												<option value="">Select equipment</option>
+												{#each equipmentOptions as equipment}
+													<option value={equipment} selected={equipment === selectedEquipment}
+														>{equipment}</option
+													>
+												{/each}
+											</select>
+										</label>
+										{#if equipmentHistory.length}
+											<p class="equipment-history">History: {equipmentHistory.join(', ')}</p>
+										{/if}
+									</div>
+								</header>
 
-                                        {#if myCurrentStationIndex !== -1}
-                                                <section class="score-card" aria-live="polite">
-                                                        <header class="score-header">
-                                                                <div>
-                                                                        <p class="score-eyebrow">Log your effort</p>
-                                                                        <h2>Station {myCurrentStationIndex + 1}</h2>
-                                                                        <p class="score-meta">{metricLabel}</p>
-                                                                </div>
-                                                                <div class="equipment-select">
-                                                                        <label>
-                                                                                Equipment used
-                                                                                <select
-                                                                                        value={selectedEquipment}
-                                                                                        on:change={(event) => setSelectedEquipment(event.currentTarget?.value ?? event.target?.value ?? '')}
-                                                                                >
-                                                                                        <option value="">Select equipment</option>
-                                                                                        {#each equipmentOptions as equipment}
-                                                                                                <option value={equipment} selected={equipment === selectedEquipment}>{equipment}</option>
-                                                                                        {/each}
-                                                                                </select>
-                                                                        </label>
-                                                                        {#if equipmentHistory.length}
-                                                                                <p class="equipment-history">History: {equipmentHistory.join(', ')}</p>
-                                                                        {/if}
-                                                                </div>
-                                                        </header>
+								{#if metricCategory === 'Cardio Machine'}
+									<div class="input-grid">
+										<label>
+											<span>Calories burned</span>
+											<input
+												type="number"
+												min="0"
+												inputmode="decimal"
+												placeholder="e.g. 75"
+												value={currentEntries[myCurrentStationIndex].score.cals}
+												on:input={(event) =>
+													handleEntryChange(myCurrentStationIndex, 'cals', event.target.value)}
+											/>
+										</label>
+										<label>
+											<span>Distance covered</span>
+											<input
+												type="text"
+												placeholder="e.g. 1.2 km or 950 m"
+												value={currentEntries[myCurrentStationIndex].score.dist}
+												on:input={(event) =>
+													handleEntryChange(myCurrentStationIndex, 'dist', event.target.value)}
+											/>
+										</label>
+									</div>
+								{:else if metricCategory === 'Resistance'}
+									<div class="input-grid">
+										<label>
+											<span>Reps completed</span>
+											<input
+												type="number"
+												min="0"
+												inputmode="decimal"
+												placeholder="e.g. 12"
+												value={currentEntries[myCurrentStationIndex].score.reps}
+												on:input={(event) =>
+													handleEntryChange(myCurrentStationIndex, 'reps', event.target.value)}
+											/>
+										</label>
+										<label>
+											<span>Weight lifted (kg)</span>
+											<input
+												type="number"
+												min="0"
+												inputmode="decimal"
+												placeholder="e.g. 40"
+												value={currentEntries[myCurrentStationIndex].score.weight}
+												on:input={(event) =>
+													handleEntryChange(myCurrentStationIndex, 'weight', event.target.value)}
+											/>
+										</label>
+									</div>
+								{:else}
+									<label class="full-width">
+										<span>Reps completed</span>
+										<input
+											type="number"
+											min="0"
+											inputmode="decimal"
+											placeholder="e.g. 30"
+											value={currentEntries[myCurrentStationIndex].score.reps}
+											on:input={(event) =>
+												handleEntryChange(myCurrentStationIndex, 'reps', event.target.value)}
+										/>
+									</label>
+								{/if}
 
-                                                        {#if metricCategory === 'Cardio Machine'}
-                                                                <div class="input-grid">
-                                                                        <label>
-                                                                                Calories burned
-                                                                                <input
-                                                                                        type="number"
-                                                                                        min="0"
-                                                                                        inputmode="decimal"
-                                                                                        placeholder="e.g. 75"
-                                                                                        value={currentEntries[myCurrentStationIndex].score.cals}
-                                                                                        on:input={(event) => handleEntryChange(myCurrentStationIndex, 'cals', event.target.value)}
-                                                                                />
-                                                                        </label>
-                                                                        <label>
-                                                                                Distance covered
-                                                                                <input
-                                                                                        type="text"
-                                                                                        placeholder="e.g. 1.2 km or 950 m"
-                                                                                        value={currentEntries[myCurrentStationIndex].score.dist}
-                                                                                        on:input={(event) => handleEntryChange(myCurrentStationIndex, 'dist', event.target.value)}
-                                                                                />
-                                                                        </label>
-                                                                </div>
-                                                        {:else if metricCategory === 'Resistance'}
-                                                                <div class="input-grid">
-                                                                        <label>
-                                                                                Reps completed
-                                                                                <input
-                                                                                        type="number"
-                                                                                        min="0"
-                                                                                        inputmode="decimal"
-                                                                                        placeholder="e.g. 12"
-                                                                                        value={currentEntries[myCurrentStationIndex].score.reps}
-                                                                                        on:input={(event) => handleEntryChange(myCurrentStationIndex, 'reps', event.target.value)}
-                                                                                />
-                                                                        </label>
-                                                                        <label>
-                                                                                Weight lifted (kg)
-                                                                                <input
-                                                                                        type="number"
-                                                                                        min="0"
-                                                                                        inputmode="decimal"
-                                                                                        placeholder="e.g. 40"
-                                                                                        value={currentEntries[myCurrentStationIndex].score.weight}
-                                                                                        on:input={(event) => handleEntryChange(myCurrentStationIndex, 'weight', event.target.value)}
-                                                                                />
-                                                                        </label>
-                                                                </div>
-                                                        {:else}
-                                                                <label class="full-width">
-                                                                        Reps completed
-                                                                        <input
-                                                                                type="number"
-                                                                                min="0"
-                                                                                inputmode="decimal"
-                                                                                placeholder="e.g. 30"
-                                                                                value={currentEntries[myCurrentStationIndex].score.reps}
-                                                                                on:input={(event) => handleEntryChange(myCurrentStationIndex, 'reps', event.target.value)}
-                                                                        />
-                                                                </label>
-                                                        {/if}
+								<label class="full-width notes-input">
+									<span>Notes (optional)</span>
+									<textarea
+										rows="2"
+										placeholder="Add cues, scaling or modifications"
+										on:input={(event) =>
+											handleEntryChange(myCurrentStationIndex, 'notes', event.target.value)}
+										>{currentEntries[myCurrentStationIndex].score.notes}</textarea
+									>
+								</label>
 
-                                                        <label class="full-width notes-input">
-                                                                Notes (optional)
-                                                                <textarea
-                                                                        rows="2"
-                                                                        placeholder="Add cues, scaling or modifications"
-                                                                        on:input={(event) => handleEntryChange(myCurrentStationIndex, 'notes', event.target.value)}
-                                                                >{currentEntries[myCurrentStationIndex].score.notes}</textarea>
-                                                        </label>
+								<div class="actions-row">
+									<button
+										class="btn btn-save"
+										on:click={() => commitStationScore(myCurrentStationIndex)}
+										disabled={!hasPendingForCurrent || rosterStatus === 'leaving'}
+									>
+										✓ Save interval
+									</button>
 
-                                                        <div class="actions-row">
-                                                                <button
-                                                                        class="btn btn-save"
-                                                                        on:click={() => commitStationScore(myCurrentStationIndex)}
-                                                                        disabled={!hasPendingForCurrent || rosterStatus === 'leaving'}
-                                                                >
-                                                                        ✓ Save interval
-                                                                </button>
+									{#if lastSaveMessage && lastSavedStationIndex === myCurrentStationIndex}
+										<p class={`save-feedback ${lastSaveType}`}>{lastSaveMessage}</p>
+									{/if}
+								</div>
 
-                                                                {#if lastSaveMessage && lastSavedStationIndex === myCurrentStationIndex}
-                                                                        <p class={`save-feedback ${lastSaveType}`}>{lastSaveMessage}</p>
-                                                                {/if}
-                                                        </div>
+								{#if hasTotals(myCurrentStationIndex)}
+									<div class="totals">
+										<h3>Totals logged</h3>
+										<ul>
+											{#if Number(cumulativeScores[myCurrentStationIndex].score.reps) > 0}
+												<li>
+													<span>Reps</span><span
+														>{cumulativeScores[myCurrentStationIndex].score.reps}</span
+													>
+												</li>
+											{/if}
+											{#if Number(cumulativeScores[myCurrentStationIndex].score.weight) > 0}
+												<li>
+													<span>Weight</span><span
+														>{cumulativeScores[myCurrentStationIndex].score.weight} kg</span
+													>
+												</li>
+											{/if}
+											{#if Number(cumulativeScores[myCurrentStationIndex].score.cals) > 0}
+												<li>
+													<span>Calories</span><span
+														>{cumulativeScores[myCurrentStationIndex].score.cals}</span
+													>
+												</li>
+											{/if}
+											{#if cumulativeScores[myCurrentStationIndex].score.dist && cumulativeScores[myCurrentStationIndex].score.dist.trim()}
+												<li>
+													<span>Distance</span><span
+														>{cumulativeScores[myCurrentStationIndex].score.dist}</span
+													>
+												</li>
+											{/if}
+											{#if equipmentHistory.length}
+												<li><span>Equipment</span><span>{equipmentHistory.join(', ')}</span></li>
+											{/if}
+											{#if cumulativeScores[myCurrentStationIndex].score.notes && cumulativeScores[myCurrentStationIndex].score.notes.trim()}
+												<li class="notes-total">
+													<span>Notes</span><span
+														>{cumulativeScores[myCurrentStationIndex].score.notes}</span
+													>
+												</li>
+											{/if}
+										</ul>
+									</div>
+								{/if}
+							</section>
+						{:else if isChipperMode}
+							<section class="score-card placeholder" aria-live="polite">
+								<div class="placeholder-clock">
+									<span class="clock-label">Time remaining</span>
+									<span class="clock-time">{formatTime(liveState.remaining)}</span>
+								</div>
+							</section>
+						{:else}
+							<section class="score-card placeholder">
+								<h2>Waiting for your station</h2>
+								<p>
+									We'll assign you to a station as soon as one opens up. Keep an eye on the timer
+									above.
+								</p>
+							</section>
+						{/if}
 
-                                                        {#if hasTotals(myCurrentStationIndex)}
-                                                                <div class="totals">
-                                                                        <h3>Totals logged</h3>
-                                                                        <ul>
-                                                                                {#if Number(cumulativeScores[myCurrentStationIndex].score.reps) > 0}
-                                                                                        <li><span>Reps</span><span>{cumulativeScores[myCurrentStationIndex].score.reps}</span></li>
-                                                                                {/if}
-                                                                                {#if Number(cumulativeScores[myCurrentStationIndex].score.weight) > 0}
-                                                                                        <li><span>Weight</span><span>{cumulativeScores[myCurrentStationIndex].score.weight} kg</span></li>
-                                                                                {/if}
-                                                                                {#if Number(cumulativeScores[myCurrentStationIndex].score.cals) > 0}
-                                                                                        <li><span>Calories</span><span>{cumulativeScores[myCurrentStationIndex].score.cals}</span></li>
-                                                                                {/if}
-                                                                                {#if cumulativeScores[myCurrentStationIndex].score.dist && cumulativeScores[myCurrentStationIndex].score.dist.trim()}
-                                                                                        <li><span>Distance</span><span>{cumulativeScores[myCurrentStationIndex].score.dist}</span></li>
-                                                                                {/if}
-                                                                                {#if equipmentHistory.length}
-                                                                                        <li><span>Equipment</span><span>{equipmentHistory.join(', ')}</span></li>
-                                                                                {/if}
-                                                                                {#if cumulativeScores[myCurrentStationIndex].score.notes && cumulativeScores[myCurrentStationIndex].score.notes.trim()}
-                                                                                        <li class="notes-total"><span>Notes</span><span>{cumulativeScores[myCurrentStationIndex].score.notes}</span></li>
-                                                                                {/if}
-                                                                        </ul>
-                                                                </div>
-                                                        {/if}
-                                                </section>
-                                        {:else if isChipperMode}
-                                                <section class="score-card placeholder" aria-live="polite">
-                                                        <div class="placeholder-clock">
-                                                                <span class="clock-label">Time remaining</span>
-                                                                <span class="clock-time">{formatTime(liveState.remaining)}</span>
-                                                        </div>
-                                                </section>
-                                        {:else}
-                                                <section class="score-card placeholder">
-                                                        <h2>Waiting for your station</h2>
-                                                        <p>We'll assign you to a station as soon as one opens up. Keep an eye on the timer above.</p>
-                                                </section>
-                                        {/if}
+						{#if liveState.isComplete}
+							<section class="post-workout-card" aria-live="polite">
+								<h2>Workout complete</h2>
+								<p>Upload your results to save them to your dashboard.</p>
+								{#if requiresCompletionLog}
+									{#if completionFinisherEntry || completionSummaryEntry}
+										<div class="completion-summary">
+											{#if completionFinisherEntry?.score?.cals}
+												<div class="summary-line">
+													<span>Finisher</span><strong
+														>{completionFinisherEntry.score.cals} cal{completionFinisherEntry.score
+															.cals === 1
+															? ''
+															: 's'}</strong
+													>
+												</div>
+											{:else if completionFinisherEntry?.score?.reps}
+												<div class="summary-line">
+													<span>Finisher</span><strong
+														>{completionFinisherEntry.score.reps} rep{completionFinisherEntry.score
+															.reps === 1
+															? ''
+															: 's'}</strong
+													>
+												</div>
+											{/if}
+											{#if completionSummaryEntry?.score?.notes}
+												<div class="summary-line">
+													<span>Progress</span><strong>{completionSummaryEntry.score.notes}</strong>
+												</div>
+											{/if}
+											<button type="button" class="btn btn-outline" on:click={openCompletionModal}
+												>Edit result</button
+											>
+										</div>
+									{:else}
+										<p class="completion-hint">Log your finish to wrap up this session.</p>
+										<button type="button" class="btn ghost" on:click={openCompletionModal}
+											>Log finish</button
+										>
+									{/if}
+								{/if}
+								<button
+									class="btn btn-primary"
+									on:click={startUpload}
+									disabled={finalSaveStatus === 'saving' || hasSavedFinalScore}
+								>
+									{hasSavedFinalScore
+										? 'Uploaded'
+										: finalSaveStatus === 'saving'
+											? 'Uploading...'
+											: 'End workout'}
+								</button>
+								{#if finalSaveMessage}
+									<p class={`status ${finalSaveStatus}`}>{finalSaveMessage}</p>
+								{/if}
+							</section>
+						{/if}
+					</main>
+				{/if}
+			</div>
+			{#if showCompletionModal}
+				<div
+					class="completion-overlay"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="completion-title"
+				>
+					<div class="completion-card">
+						<h3 id="completion-title">Log your finish</h3>
+						<p>Capture your result so we can save it with your workout.</p>
+						{#if isChipperMode}
+							{#if finisherMetric}
+								<label class="modal-field">
+									<span>{finisherMetric.label}</span>
+									<input
+										type="number"
+										min="0"
+										inputmode="numeric"
+										placeholder={finisherMetric.placeholder}
+										bind:value={completionForm.finisherValue}
+									/>
+								</label>
+							{/if}
+							<label class="modal-checkbox">
+								<input type="checkbox" bind:checked={completionForm.completedChipper} />
+								<span>I completed the full chipper</span>
+							</label>
+							{#if !completionForm.completedChipper}
+								<label class="modal-field">
+									<span>Last exercise reached</span>
+									<select bind:value={completionForm.progressExercise}>
+										{#each chipperSteps as step}
+											<option value={step.name}>{step.name}</option>
+										{/each}
+									</select>
+								</label>
+								<label class="modal-field">
+									<span>Reps completed</span>
+									<input
+										type="number"
+										min="0"
+										inputmode="numeric"
+										placeholder="e.g. 20"
+										bind:value={completionForm.progressReps}
+									/>
+								</label>
+							{/if}
+						{:else if isAmrapType}
+							<div class="modal-grid">
+								<label class="modal-field">
+									<span>Full rounds</span>
+									<input
+										type="number"
+										min="0"
+										inputmode="numeric"
+										placeholder="e.g. 7"
+										bind:value={completionForm.amrapRounds}
+									/>
+								</label>
+								<label class="modal-field">
+									<span>Extra reps</span>
+									<input
+										type="number"
+										min="0"
+										inputmode="numeric"
+										placeholder="e.g. 15"
+										bind:value={completionForm.amrapReps}
+									/>
+								</label>
+							</div>
+						{/if}
+						{#if completionError}
+							<p class="completion-error">{completionError}</p>
+						{/if}
+						<div class="modal-actions">
+							<button type="button" class="btn btn-outline" on:click={cancelCompletionModal}
+								>Cancel</button
+							>
+							<button type="button" class="btn btn-primary" on:click={submitCompletionForm}
+								>Save result</button
+							>
+						</div>
+					</div>
+				</div>
+			{/if}
 
-                                        {#if liveState.isComplete}
-                                                <section class="post-workout-card" aria-live="polite">
-                                                        <h2>Workout complete</h2>
-                                                        <p>Upload your results to save them to your dashboard.</p>
-                                                        {#if requiresCompletionLog}
-                                                                {#if completionFinisherEntry || completionSummaryEntry}
-                                                                        <div class="completion-summary">
-                                                                                {#if completionFinisherEntry?.score?.cals}
-                                                                                        <div class="summary-line"><span>Finisher</span><strong>{completionFinisherEntry.score.cals} cal{completionFinisherEntry.score.cals === 1 ? '' : 's'}</strong></div>
-                                                                                {:else if completionFinisherEntry?.score?.reps}
-                                                                                        <div class="summary-line"><span>Finisher</span><strong>{completionFinisherEntry.score.reps} rep{completionFinisherEntry.score.reps === 1 ? '' : 's'}</strong></div>
-                                                                                {/if}
-                                                                                {#if completionSummaryEntry?.score?.notes}
-                                                                                        <div class="summary-line"><span>Progress</span><strong>{completionSummaryEntry.score.notes}</strong></div>
-                                                                                {/if}
-                                                                                <button type="button" class="btn btn-outline" on:click={openCompletionModal}>Edit result</button>
-                                                                        </div>
-                                                                {:else}
-                                                                        <p class="completion-hint">Log your finish to wrap up this session.</p>
-                                                                        <button type="button" class="btn ghost" on:click={openCompletionModal}>Log finish</button>
-                                                                {/if}
-                                                        {/if}
-                                                        <button
-                                                                class="btn btn-primary"
-                                                                on:click={startUpload}
-                                                                disabled={finalSaveStatus === 'saving' || hasSavedFinalScore}
-                                                        >
-                                                                {hasSavedFinalScore ? 'Uploaded' : finalSaveStatus === 'saving' ? 'Uploading...' : 'End workout'}
-                                                        </button>
-                                                        {#if finalSaveMessage}
-                                                                <p class={`status ${finalSaveStatus}`}>{finalSaveMessage}</p>
-                                                        {/if}
-                                                </section>
-                                        {/if}
-                                </main>
-                        {/if}
-                </div>
-        {#if showCompletionModal}
-                <div class="completion-overlay" role="dialog" aria-modal="true" aria-labelledby="completion-title">
-                        <div class="completion-card">
-                                <h3 id="completion-title">Log your finish</h3>
-                                <p>Capture your result so we can save it with your workout.</p>
-                                {#if isChipperMode}
-                                        {#if finisherMetric}
-                                                <label class="modal-field">
-                                                        <span>{finisherMetric.label}</span>
-                                                        <input
-                                                                type="number"
-                                                                min="0"
-                                                                inputmode="numeric"
-                                                                placeholder={finisherMetric.placeholder}
-                                                                bind:value={completionForm.finisherValue}
-                                                        />
-                                                </label>
-                                        {/if}
-                                        <label class="modal-checkbox">
-                                                <input type="checkbox" bind:checked={completionForm.completedChipper} />
-                                                <span>I completed the full chipper</span>
-                                        </label>
-                                        {#if !completionForm.completedChipper}
-                                                <label class="modal-field">
-                                                        <span>Last exercise reached</span>
-                                                        <select bind:value={completionForm.progressExercise}>
-                                                                {#each chipperSteps as step}
-                                                                        <option value={step.name}>{step.name}</option>
-                                                                {/each}
-                                                        </select>
-                                                </label>
-                                                <label class="modal-field">
-                                                        <span>Reps completed</span>
-                                                        <input
-                                                                type="number"
-                                                                min="0"
-                                                                inputmode="numeric"
-                                                                placeholder="e.g. 20"
-                                                                bind:value={completionForm.progressReps}
-                                                        />
-                                                </label>
-                                        {/if}
-                                {:else if isAmrapType}
-                                        <div class="modal-grid">
-                                                <label class="modal-field">
-                                                        <span>Full rounds</span>
-                                                        <input
-                                                                type="number"
-                                                                min="0"
-                                                                inputmode="numeric"
-                                                                placeholder="e.g. 7"
-                                                                bind:value={completionForm.amrapRounds}
-                                                        />
-                                                </label>
-                                                <label class="modal-field">
-                                                        <span>Extra reps</span>
-                                                        <input
-                                                                type="number"
-                                                                min="0"
-                                                                inputmode="numeric"
-                                                                placeholder="e.g. 15"
-                                                                bind:value={completionForm.amrapReps}
-                                                        />
-                                                </label>
-                                        </div>
-                                {/if}
-                                {#if completionError}
-                                        <p class="completion-error">{completionError}</p>
-                                {/if}
-                                <div class="modal-actions">
-                                        <button type="button" class="btn btn-outline" on:click={cancelCompletionModal}>Cancel</button>
-                                        <button type="button" class="btn btn-primary" on:click={submitCompletionForm}>Save result</button>
-                                </div>
-                        </div>
-                </div>
-        {/if}
-
-        {#if showFeedbackModal}
-                <div class="feedback-overlay" role="dialog" aria-modal="true" aria-labelledby="feedback-title">
-                        <div class="feedback-card">
-                                <h3 id="feedback-title">How was that session?</h3>
-                                <p>Share anonymous feedback to help shape future workouts.</p>
-                                <div class="upload-recap" aria-live="polite">
-                                        <p class="upload-recap-label">Upload preview</p>
-                                        <p class="upload-recap-line">{uploadWeightSummary}</p>
-                                        <p class="upload-recap-line">{uploadCompletionSummary}</p>
-                                </div>
-                                <div class="feedback-stars" role="group" aria-label="Rate this workout">
-                                        {#each [1, 2, 3, 4, 5] as star}
-                                                <button
-                                                        type="button"
-                                                        class="star-button"
-                                                        class:active={feedbackRating >= star}
-                                                        aria-label={`${star} star${star === 1 ? '' : 's'}`}
-                                                        aria-pressed={feedbackRating === star}
-                                                        on:click={() => (feedbackRating = star)}
-                                                >
-                                                        ★
-                                                </button>
-                                        {/each}
-                                </div>
-                                <textarea
-                                        aria-label="Optional feedback comments"
-                                        bind:value={feedbackComment}
-                                        placeholder="Add an optional comment (your name won't be shown)"
-                                ></textarea>
-                                <div class="feedback-actions">
-                                        <button type="button" class="btn btn-outline" on:click={cancelFeedback}>Cancel</button>
-                                        <button
-                                                type="button"
-                                                class="btn ghost"
-                                                on:click={() => handleFeedbackSubmit(false)}
-                                        >
-                                                Skip &amp; Upload
-                                        </button>
-                                        <button
-                                                type="button"
-                                                class="btn btn-primary"
-                                                on:click={() => handleFeedbackSubmit(true)}
-                                        >
-                                                Submit &amp; Upload
-                                        </button>
-                                </div>
-                        </div>
-                </div>
-        {/if}
+			{#if showFeedbackModal}
+				<div
+					class="feedback-overlay"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="feedback-title"
+				>
+					<div class="feedback-card">
+						<h3 id="feedback-title">How was that session?</h3>
+						<p>Share anonymous feedback to help shape future workouts.</p>
+						<div class="upload-recap" aria-live="polite">
+							<p class="upload-recap-label">Upload preview</p>
+							<p class="upload-recap-line">{uploadWeightSummary}</p>
+							<p class="upload-recap-line">{uploadCompletionSummary}</p>
+						</div>
+						<div class="feedback-stars" role="group" aria-label="Rate this workout">
+							{#each [1, 2, 3, 4, 5] as star}
+								<button
+									type="button"
+									class="star-button"
+									class:active={feedbackRating >= star}
+									aria-label={`${star} star${star === 1 ? '' : 's'}`}
+									aria-pressed={feedbackRating === star}
+									on:click={() => (feedbackRating = star)}
+								>
+									★
+								</button>
+							{/each}
+						</div>
+						<textarea
+							aria-label="Optional feedback comments"
+							bind:value={feedbackComment}
+							placeholder="Add an optional comment (your name won't be shown)"
+						></textarea>
+						<div class="feedback-actions">
+							<button type="button" class="btn btn-outline" on:click={cancelFeedback}>Cancel</button
+							>
+							<button type="button" class="btn ghost" on:click={() => handleFeedbackSubmit(false)}>
+								Skip &amp; Upload
+							</button>
+							<button
+								type="button"
+								class="btn btn-primary"
+								on:click={() => handleFeedbackSubmit(true)}
+							>
+								Submit &amp; Upload
+							</button>
+						</div>
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
 </div>
-</div>
-
-
 
 <style>
-:global(body) {
-        background-color: var(--bg-main);
-        color: var(--text-primary);
-        font-family: var(--font-body);
-}
-
-.tracker-container {
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-        background: var(--deep-space);
-        padding: 1rem;
-        gap: 1rem;
-        overflow-y: auto;
-}
-
-.tracker-layout {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        height: auto;
-        min-height: 0;
-}
-
-.standard-content-grid {
-        flex: 1;
-        display: grid;
-        grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-        gap: 1rem;
-        min-height: 0;
-}
-
-.chipper-content-grid {
-        flex: 1;
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
-        gap: 1rem;
-        min-height: 0;
-}
-
-.session-sidebar,
-.session-main,
-.chipper-overview {
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 20px;
-        padding: 1.5rem;
-        display: flex;
-        flex-direction: column;
-        gap: 1.25rem;
-        overflow-y: auto;
-        min-height: 0;
-}
-
-.timer-card {
-        width: 100%;
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 20px;
-        padding: 1.5rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        text-align: left;
-}
-
-.timer-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-}
-
-.phase-label {
-        font-family: var(--font-display);
-        font-size: 1.35rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-secondary);
-}
-
-.time-display {
-        font-family: var(--font-display);
-        font-size: 3.5rem;
-        color: var(--brand-yellow);
-        line-height: 1;
-}
-
-@media (max-width: 900px) {
-        .standard-content-grid,
-        .chipper-content-grid {
-                grid-template-columns: 1fr;
-        }
-
-        .session-sidebar,
-        .session-main,
-        .chipper-overview {
-                max-height: none;
-        }
-}
-
-.phase-meta {
-        margin-top: 0.25rem;
-        display: flex;
-        gap: 0.5rem;
-        justify-content: flex-start;
-        flex-wrap: wrap;
-}
-
-.phase-chip {
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 999px;
-        padding: 0.2rem 0.75rem;
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: var(--text-muted);
-}
-
-.station-overview,
-.workout-overview {
-        background: rgba(15, 23, 42, 0.55);
-        border: 1px solid var(--border-color);
-        border-radius: 16px;
-        padding: 1.25rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-}
-
-.amrap-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.65rem;
-}
-
-.amrap-line {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.75rem;
-}
-
-.amrap-order {
-        width: 2.25rem;
-        height: 2.25rem;
-        border-radius: 10px;
-        border: 1px solid var(--border-color);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 700;
-        background: var(--surface-1);
-}
-
-.amrap-details {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        gap: 0.35rem;
-}
-
-.amrap-name {
-        margin: 0;
-        font-weight: 600;
-}
-
-.amrap-simple-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: 1.25rem;
-        align-items: stretch;
-}
-
-.amrap-time-card,
-.amrap-move-card,
-.amrap-round-card {
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 18px;
-        padding: 1.5rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        min-height: 100%;
-}
-
-.amrap-clock {
-        font-family: var(--font-display);
-        font-size: 4rem;
-        color: var(--brand-yellow);
-        margin: 0;
-}
-
-.amrap-move-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.8rem;
-}
-
-.amrap-move-list li {
-        display: flex;
-        gap: 0.75rem;
-        align-items: flex-start;
-}
-
-.amrap-move-details {
-        display: flex;
-        flex-direction: column;
-        gap: 0.2rem;
-}
-
-.amrap-move-details strong {
-        font-size: 1.05rem;
-}
-
-.amrap-desc {
-        color: var(--text-muted);
-        font-size: 0.9rem;
-}
-
-.amrap-round-controls {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(64px, 1fr));
-        gap: 0.5rem;
-        align-items: center;
-}
-
-.round-step {
-        background: var(--surface-2);
-        border: 1px solid var(--border-color);
-        border-radius: 14px;
-        color: var(--text-secondary);
-        font-size: 1.8rem;
-        font-weight: 700;
-        padding: 0.6rem;
-        cursor: pointer;
-        transition: transform 0.1s ease, border-color 0.1s ease;
-}
-
-.round-step:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-}
-
-.round-step:not(:disabled):hover,
-.round-step:not(:disabled):focus-visible {
-        transform: translateY(-1px);
-        border-color: var(--brand-yellow);
-        outline: none;
-}
-
-.amrap-round-display {
-        text-align: center;
-        font-family: var(--font-display);
-        font-size: 2.8rem;
-        color: var(--brand-yellow);
-        background: rgba(234, 179, 8, 0.08);
-        border: 1px solid rgba(234, 179, 8, 0.25);
-        border-radius: 16px;
-        padding: 0.75rem 0.5rem;
-}
-
-.extra-reps-field {
-        display: flex;
-        flex-direction: column;
-        gap: 0.35rem;
-        margin-top: 0.5rem;
-}
-
-.extra-reps-field input {
-        background: var(--surface-2);
-        border: 1px solid var(--border-color);
-        border-radius: 12px;
-        color: var(--text-primary);
-        padding: 0.65rem 0.75rem;
-        font-size: 1rem;
-}
-
-.round-hint {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-}
-
-.eyebrow {
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        font-size: 0.75rem;
-        color: var(--text-muted);
-        margin: 0;
-}
-
-.station-heading h2,
-.workout-overview h2 {
-        margin: 0;
-        font-size: 1.4rem;
-        color: var(--text-secondary);
-}
-
-.station-meta {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.9rem;
-}
-
-.workout-overview ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-}
-
-.workout-overview li {
-        display: flex;
-        gap: 0.75rem;
-        align-items: flex-start;
-        color: var(--text-secondary);
-}
-
-.workout-index {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        background: rgba(148, 163, 184, 0.2);
-        font-family: var(--font-display);
-        font-size: 0.9rem;
-        color: var(--brand-yellow);
-}
-
-.workout-info {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-}
-
-.workout-info strong {
-        font-size: 0.95rem;
-        color: var(--text-secondary);
-}
-
-.workout-info span {
-        font-size: 0.8rem;
-        color: var(--text-muted);
-}
-
-.equipment-options-list {
-        margin-top: 0.75rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-}
-
-.equipment-options-label {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-muted);
-}
-
-.equipment-options-values {
-        font-size: 0.9rem;
-        color: var(--text-secondary);
-}
-
-.station-next {
-        margin-top: 0.75rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-}
-
-.station-next h3 {
-        margin: 0;
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--text-muted);
-}
-
-.station-chip {
-        align-self: flex-start;
-        background: rgba(148, 163, 184, 0.18);
-        border-radius: 999px;
-        padding: 0.25rem 0.75rem;
-        font-size: 0.75rem;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        color: var(--text-secondary);
-}
-
-.pairing-controls {
-        display: flex;
-        gap: 1rem;
-        align-items: center;
-        justify-content: space-between;
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 16px;
-        padding: 1.25rem 1.5rem;
-        text-align: left;
-}
-
-.pairing-copy h2 {
-        margin: 0 0 0.25rem;
-        font-size: 1.1rem;
-        color: var(--text-secondary);
-}
-
-.pairing-copy p {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.9rem;
-}
-
-.pairing-error {
-        margin-top: 0.5rem;
-        color: #f87171;
-        font-size: 0.85rem;
-}
-
-.pairing-actions {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        flex: 1;
-}
-
-.pairing-toggle {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(140px, 1fr));
-        gap: 0.75rem;
-}
-
-.pairing-toggle button {
-        border-radius: 999px;
-        padding: 0.65rem 1rem;
-        font-weight: 700;
-        cursor: pointer;
-        border: 1px solid var(--border-color);
-        background: transparent;
-        color: var(--text-secondary);
-        transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.pairing-toggle button.active {
-        background: var(--brand-yellow);
-        border-color: var(--brand-yellow);
-        color: var(--deep-space);
-}
-
-.pairing-toggle button.locked {
-        border-style: dashed;
-}
-
-.pairing-toggle button:disabled {
-        opacity: 0.6;
-        cursor: not-allowed;
-}
-
-.pairing-status {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-}
-
-.pairing-note {
-        margin: -0.35rem 0 0;
-        color: var(--text-muted);
-        font-size: 0.8rem;
-}
-
-.chipper-overview {
-        text-align: left;
-}
-
-.chipper-header h2 {
-        margin: 0;
-        font-size: 1.4rem;
-        color: var(--text-secondary);
-}
-
-.chipper-header p {
-        margin: 0.35rem 0 0;
-        color: var(--text-muted);
-}
-
-.chipper-pyramid {
-        display: grid;
-        gap: 1rem;
-}
-
-.chipper-tier {
-        display: grid;
-        grid-template-columns: 80px 1fr;
-        gap: 1rem;
-        align-items: start;
-}
-
-.tier-reps {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 68px;
-        height: 68px;
-        border-radius: 14px;
-        background: var(--surface-2, rgba(255, 255, 255, 0.04));
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        font-family: var(--font-display);
-        font-size: 1.4rem;
-        color: var(--brand-yellow);
-}
-
-.tier-movements {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: grid;
-        gap: 0.45rem;
-}
-
-.tier-movements li {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 0.5rem;
-        color: var(--text-primary);
-        font-size: 0.95rem;
-}
-
-.tier-item {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 0.5rem;
-        width: 100%;
-        cursor: pointer;
-}
-
-.tier-checkbox {
-        margin-left: auto;
-        width: 1.05rem;
-        height: 1.05rem;
-        accent-color: var(--brand-yellow);
-        cursor: pointer;
-}
-
-.tier-movements li.completed .tier-name {
-        text-decoration: line-through;
-        color: var(--text-muted);
-}
-
-.tier-movements li.completed .tier-category {
-        opacity: 0.6;
-}
-
-.tier-movements li.completed .tier-order {
-        color: var(--text-muted);
-        opacity: 0.6;
-}
-
-.tier-order {
-        font-weight: 600;
-        color: var(--text-muted);
-}
-
-.tier-category {
-        background: rgba(255, 255, 255, 0.08);
-        border-radius: 999px;
-        padding: 0.1rem 0.6rem;
-        font-size: 0.75rem;
-        color: var(--text-muted);
-}
-
-.chipper-empty {
-        margin: 0;
-        color: var(--text-muted);
-        font-style: italic;
-}
-
-.chipper-finisher-card {
-        display: grid;
-        grid-template-columns: 90px 1fr;
-        gap: 1rem;
-        align-items: start;
-        padding-top: 1rem;
-        border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.finisher-label {
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--text-muted);
-}
-
-.finisher-details {
-        display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-        color: var(--text-muted);
-}
-
-.finisher-details strong {
-        color: var(--text-secondary);
-        font-size: 1rem;
-}
-
-@media (max-width: 720px) {
-        .chipper-tier {
-                grid-template-columns: 1fr;
-        }
-
-        .tier-reps {
-                width: 54px;
-                height: 54px;
-                font-size: 1.1rem;
-        }
-
-        .chipper-finisher-card {
-                grid-template-columns: 1fr;
-        }
-}
-
-.pairing-summary {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 16px;
-        padding: 1.25rem 1.5rem;
-        text-align: left;
-}
-
-.summary-row {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        align-items: center;
-}
-
-.summary-chip {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 999px;
-        padding: 0.25rem 0.75rem;
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        border: 1px solid transparent;
-}
-
-.summary-chip.solo {
-        background: rgba(59, 130, 246, 0.16);
-        border-color: rgba(59, 130, 246, 0.35);
-        color: #60a5fa;
-}
-
-.summary-chip.partner {
-        background: rgba(34, 197, 94, 0.16);
-        border-color: rgba(34, 197, 94, 0.35);
-        color: #34d399;
-}
-
-.summary-chip.role {
-        background: rgba(253, 224, 71, 0.16);
-        border-color: rgba(253, 224, 71, 0.35);
-        color: var(--brand-yellow);
-}
-
-.summary-chip.locked {
-        background: rgba(148, 163, 184, 0.12);
-        border-color: rgba(148, 163, 184, 0.3);
-        color: var(--text-muted);
-}
-
-.btn {
-        border-radius: 999px;
-        padding: 0.65rem 1.5rem;
-        font-weight: 700;
-        cursor: pointer;
-        border: none;
-        transition: transform 140ms ease, box-shadow 140ms ease;
-        font-size: 1rem;
-}
-
-.btn:disabled {
-        opacity: 0.55;
-        cursor: not-allowed;
-        transform: none;
-        box-shadow: none;
-}
-
-.btn-primary {
-        background: var(--brand-green);
-        color: var(--text-primary);
-        box-shadow: 0 12px 30px -18px rgba(22, 163, 74, 0.9);
-}
-
-.btn-primary:not(:disabled):hover {
-        transform: translateY(-2px);
-        box-shadow: 0 18px 40px -16px rgba(22, 163, 74, 0.9);
-}
-
-.btn-outline {
-        background: transparent;
-        border: 1px solid var(--border-color);
-        color: var(--text-secondary);
-}
-
-.btn-outline:not(:disabled):hover {
-        transform: translateY(-2px);
-        box-shadow: 0 12px 24px -18px rgba(148, 163, 184, 0.6);
-}
-
-.btn-save {
-        margin-top: 1rem;
-        width: 100%;
-        border-radius: 12px;
-        background: var(--brand-green);
-        color: var(--text-primary);
-        box-shadow: 0 16px 32px -20px rgba(22, 163, 74, 0.9);
-}
-
-.btn-save:not(:disabled):hover {
-        transform: translateY(-2px);
-        box-shadow: 0 22px 45px -18px rgba(22, 163, 74, 0.9);
-}
-
-.score-card {
-        background: var(--surface-1);
-        width: 100%;
-        padding: 1.75rem;
-        border-radius: 20px;
-        border: 1px solid var(--border-color);
-        text-align: left;
-        box-shadow: 0 18px 45px -35px rgba(15, 23, 42, 0.65);
-        display: flex;
-        flex-direction: column;
-        gap: 1.25rem;
-}
-
-.score-rest-banner {
-        background: rgba(148, 163, 184, 0.14);
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        border-radius: 14px;
-        padding: 0.75rem 1rem;
-        font-size: 0.9rem;
-        color: var(--text-secondary);
-}
-
-.score-equipment-selector {
-        display: flex;
-        flex-direction: column;
-        gap: 0.65rem;
-}
-
-.selector-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.75rem;
-}
-
-.selector-label {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-muted);
-}
-
-.clear-selection {
-        background: transparent;
-        border: none;
-        color: var(--text-muted);
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        cursor: pointer;
-        padding: 0.15rem 0.35rem;
-}
-
-.clear-selection:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-}
-
-.score-card.placeholder {
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-        background: rgba(15, 23, 42, 0.6);
-        border-style: dashed;
-        box-shadow: none;
-        min-height: 200px;
-}
-
-.placeholder-clock {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 0.35rem;
-}
-
-.clock-label {
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-secondary);
-}
-
-.clock-time {
-        font-family: var(--font-display);
-        font-size: clamp(2.8rem, 3vw + 1rem, 3.6rem);
-        font-weight: 600;
-        color: var(--brand-yellow);
-}
-
-.score-card.placeholder h2 {
-        margin: 0 0 0.5rem;
-        font-size: 1.4rem;
-        color: var(--text-secondary);
-}
-
-.score-card.placeholder p {
-        margin: 0;
-        font-size: 0.9rem;
-        color: var(--text-muted);
-}
-
-.score-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 1.5rem;
-        flex-wrap: wrap;
-}
-
-.score-eyebrow {
-        font-size: 0.75rem;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--text-muted);
-}
-
-.score-subtitle {
-        margin: 0;
-        font-size: 0.9rem;
-        color: var(--text-muted);
-}
-
-.score-helper {
-        margin: 1rem 0 0;
-        font-size: 0.85rem;
-        color: var(--text-muted);
-        line-height: 1.4;
-}
-
-.score-meta {
-        margin-top: 0;
-        display: flex;
-        gap: 0.5rem;
-        justify-content: flex-end;
-        flex-wrap: wrap;
-        align-items: center;
-}
-
-.score-chip {
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid var(--border-color);
-        border-radius: 999px;
-        padding: 0.3rem 0.75rem;
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--text-secondary);
-}
-
-.score-chip.emphasis {
-        background: rgba(253, 224, 71, 0.16);
-        border-color: rgba(253, 224, 71, 0.45);
-        color: var(--brand-yellow);
-}
-
-.score-chip.subtle {
-        background: rgba(148, 163, 184, 0.12);
-        border-color: rgba(148, 163, 184, 0.3);
-        color: var(--text-muted);
-}
-
-.input-grid {
-        margin-top: 1.5rem;
-        display: grid;
-        gap: 1rem;
-}
-
-.input-grid.two-column {
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.input-field {
-        display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-}
-
-.input-field.full {
-        grid-column: 1 / -1;
-}
-
-
-
-
-
-.actions-row {
-        margin-top: 1.5rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        align-items: stretch;
-}
-
-.actions-row .btn-save {
-        margin-top: 0;
-}
-
-.actions-row .save-feedback {
-        margin: 0;
-        text-align: center;
-}
-
-.save-feedback {
-        font-size: 0.85rem;
-}
-
-.save-feedback.success {
-        color: var(--brand-green);
-}
-
-.save-feedback.error {
-        color: #f87171;
-}
-
-.save-feedback.auto {
-        color: var(--text-secondary);
-}
-
-.save-feedback.info {
-        color: var(--text-muted);
-}
-
-.totals {
-        margin-top: 1.5rem;
-        text-align: left;
-        background: rgba(15, 23, 42, 0.65);
-        border: 1px solid var(--border-color);
-        border-radius: 14px;
-        padding: 1.1rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-}
-
-.totals h3 {
-        margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-secondary);
-}
-
-.totals ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-}
-
-.totals li {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 0.75rem;
-        color: var(--text-primary);
-        font-size: 0.95rem;
-}
-
-.totals li span:first-child {
-        color: var(--text-muted);
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-}
-
-.totals li span:last-child {
-        font-weight: 600;
-        font-size: 0.95rem;
-        text-align: right;
-}
-
-.notes-total span:last-child {
-        white-space: pre-wrap;
-        font-family: var(--font-body);
-        font-size: 0.85rem;
-        font-weight: 400;
-}
-
-.start-callout {
-        margin: 0 0 0.75rem;
-        padding: 0.75rem;
-        border-radius: 12px;
-        background: rgba(56, 189, 248, 0.08);
-        border: 1px solid rgba(56, 189, 248, 0.25);
-        font-size: 0.9rem;
-        color: var(--text-secondary);
-        line-height: 1.5;
-}
-.start-callout strong {
-        color: var(--brand-yellow);
-}
-.rest-callout {
-        margin: 0.75rem 0;
-        padding: 0.85rem 1rem;
-        border-radius: 12px;
-        background: rgba(148, 163, 184, 0.12);
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        color: var(--text-secondary);
-        font-size: 0.95rem;
-        line-height: 1.5;
-}
-.rest-callout strong {
-        color: var(--text-primary);
-}
-.start-role {
-        display: inline-block;
-        margin-right: 0.5rem;
-        padding: 0.15rem 0.55rem;
-        border-radius: 999px;
-        background: rgba(253, 224, 71, 0.18);
-        color: var(--brand-yellow);
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        letter-spacing: 0.12em;
-}
-
-.upcoming-note {
-        margin: -0.25rem 0 0.25rem;
-        font-size: 0.85rem;
-        color: var(--text-muted);
-}
-
-.upcoming-note strong {
-        color: var(--text-secondary);
-}
-
-.station-heading {
-        display: flex;
-        flex-direction: column;
-        gap: 0.35rem;
-}
-
-.station-eyebrow {
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--text-muted);
-}
-
-.station-heading h2 {
-        margin: 0;
-        font-size: 1.4rem;
-        color: var(--text-secondary);
-}
-
-.station-meta {
-        margin: 0;
-        font-size: 0.9rem;
-        color: var(--text-muted);
-        display: flex;
-        gap: 0.35rem;
-        align-items: center;
-}
-
-.station-meta span[aria-hidden='true'] {
-        color: var(--text-muted);
-}
-
-.task-list {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-}
-
-.task-line {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.75rem;
-        font-size: 0.95rem;
-}
-
-.task-label {
-        width: 22px;
-        height: 22px;
-        border-radius: 50%;
-        font-size: 0.6rem;
-        flex-shrink: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-}
-
-.task-content {
-        display: flex;
-        flex-direction: column;
-        gap: 0.3rem;
-        align-items: flex-start;
-}
-
-.task-text {
-        color: var(--text-primary);
-        font-size: 1rem;
-        font-weight: 500;
-}
-
-.task-chip {
-        background: rgba(148, 163, 184, 0.12);
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        border-radius: 999px;
-        padding: 0.2rem 0.65rem;
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: var(--text-muted);
-}
-.task-label.p1 {
-        background: #34d39933;
-        color: #34d399;
-}
-
-.task-label.p2 {
-        background: #f472b633;
-        color: #f472b6;
-}
-
-.post-workout-card {
-        background: var(--surface-1);
-        border: 1px solid var(--border-color);
-        border-radius: 16px;
-        padding: 1.5rem;
-        text-align: center;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-}
-
-.post-workout-card h2 {
-        margin-bottom: 0.5rem;
-        font-size: 1.4rem;
-        color: var(--text-secondary);
-}
-
-.post-workout-card p {
-        margin: 0.5rem 0 1rem;
-        color: var(--text-muted);
-}
-
-.completion-summary {
-        display: flex;
-        flex-direction: column;
-        gap: 0.65rem;
-        background: rgba(15, 23, 42, 0.55);
-        border: 1px solid var(--border-color);
-        border-radius: 12px;
-        padding: 1rem;
-        text-align: left;
-}
-
-.summary-line {
-        display: flex;
-        justify-content: space-between;
-        gap: 1rem;
-        font-size: 0.95rem;
-        color: var(--text-secondary);
-}
-
-.summary-line span:first-child {
-        color: var(--text-muted);
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-}
-
-.completion-hint {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.9rem;
-}
-
-.post-workout-card .status {
-        margin-top: 0.75rem;
-        font-size: 0.9rem;
-}
-
-.post-workout-card .status.success {
-        color: var(--brand-green);
-}
-
-.post-workout-card .status.error {
-        color: #f87171;
-}
-
-.post-workout-card .status.warning {
-        color: var(--brand-yellow);
-}
-
-.completion-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, 0.75);
-        backdrop-filter: blur(6px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1.5rem;
-        z-index: 1100;
-}
-
-.completion-card {
-        background: var(--bg-panel);
-        border: 1px solid var(--border-color);
-        border-radius: 18px;
-        padding: 1.75rem;
-        width: 100%;
-        max-width: 420px;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        box-shadow: 0 26px 65px rgba(15, 23, 42, 0.55);
-}
-
-.completion-card h3 {
-        margin: 0;
-        font-family: var(--font-display);
-        font-size: 1.8rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--brand-yellow);
-}
-
-.modal-field {
-        display: flex;
-        flex-direction: column;
-        gap: 0.4rem;
-        text-align: left;
-}
-
-.modal-field span {
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--text-muted);
-}
-
-.modal-field input,
-.modal-field select {
-        border-radius: 12px;
-        border: 1px solid var(--border-color);
-        background: var(--deep-space);
-        color: var(--text-primary);
-        padding: 0.55rem 0.75rem;
-        font-size: 1rem;
-}
-
-.modal-grid {
-        display: grid;
-        gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-}
-
-.modal-checkbox {
-        display: flex;
-        align-items: center;
-        gap: 0.65rem;
-        font-size: 0.9rem;
-        color: var(--text-secondary);
-}
-
-.modal-checkbox input {
-        width: 18px;
-        height: 18px;
-}
-
-.modal-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: 0.75rem;
-}
-
-.completion-error {
-        color: #f87171;
-        font-size: 0.9rem;
-        margin: 0;
-}
-
-.feedback-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, 0.75);
-        backdrop-filter: blur(6px);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1.5rem;
-        z-index: 1200;
-}
-
-.feedback-card {
-        background: var(--bg-panel);
-        border: 1px solid var(--border-color);
-        border-radius: 20px;
-        padding: 2rem;
-        width: 100%;
-        max-width: 420px;
-        display: flex;
-        flex-direction: column;
-        gap: 1.25rem;
-        box-shadow: 0 30px 70px rgba(15, 23, 42, 0.45);
-}
-
-.feedback-card h3 {
-        margin: 0;
-        font-family: var(--font-display);
-        letter-spacing: 0.08em;
-        color: var(--brand-yellow);
-        font-size: 2.1rem;
-        text-transform: uppercase;
-}
-
-.feedback-card p {
-        margin: 0;
-        color: var(--text-secondary);
-}
-
-.upload-recap {
-        border: 1px solid var(--border-color);
-        border-radius: 14px;
-        padding: 0.85rem 1rem;
-        background: rgba(15, 23, 42, 0.45);
-        display: grid;
-        gap: 0.3rem;
-}
-
-.upload-recap-label {
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-        color: var(--text-primary);
-        margin: 0;
-}
-
-.upload-recap-line {
-        margin: 0;
-        color: var(--text-secondary);
-}
-
-.feedback-stars {
-        display: flex;
-        gap: 0.5rem;
-        justify-content: center;
-}
-
-.star-button {
-        background: transparent;
-        border: none;
-        color: rgba(148, 163, 184, 0.6);
-        font-size: 2.25rem;
-        cursor: pointer;
-        transition: transform var(--transition), color var(--transition);
-}
-
-.star-button.active,
-.star-button:hover,
-.star-button:focus-visible {
-        color: var(--brand-yellow);
-        transform: scale(1.05);
-        outline: none;
-}
-
-.feedback-card textarea {
-        background: var(--deep-space);
-        border: 1px solid var(--border-color);
-        border-radius: 14px;
-        color: var(--text-primary);
-        padding: 0.85rem 1rem;
-        min-height: 120px;
-        resize: vertical;
-        font-family: inherit;
-}
-
-.feedback-card textarea::placeholder {
-        color: rgba(148, 163, 184, 0.7);
-}
-
-.feedback-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-        justify-content: flex-end;
-}
-
-.feedback-actions .btn {
-        flex: 1;
-        min-width: 140px;
-}
-
-.btn.ghost {
-        background: transparent;
-        border: 1px solid var(--border-color);
-        color: var(--text-secondary);
-}
-
-.btn.ghost:not(:disabled):hover,
-.btn.ghost:focus-visible {
-        color: var(--text-primary);
-        border-color: var(--text-secondary);
-}
-
-@media (max-width: 640px) {
-        .tracker-container {
-                padding: 1rem;
-        }
-
-        .session-sidebar,
-        .session-main {
-                padding: 1.25rem;
-        }
-
-        .pairing-controls {
-                flex-direction: column;
-                align-items: flex-start;
-        }
-
-        .pairing-actions {
-                width: 100%;
-        }
-
-        .pairing-toggle {
-                grid-template-columns: 1fr;
-        }
-
-        .pairing-toggle button {
-                width: 100%;
-        }
-
-        .btn {
-                width: 100%;
-                justify-content: center;
-        }
-
-        .score-card {
-                padding: 1.25rem;
-        }
-}
+	:global(body) {
+		background-color: var(--bg-main);
+		color: var(--text-primary);
+		font-family: var(--font-body);
+	}
+
+	.tracker-container {
+		min-height: 100vh;
+		background:
+			radial-gradient(circle at 6% 0%, rgba(56, 189, 248, 0.2), transparent 28rem),
+			radial-gradient(circle at 90% 12%, rgba(250, 204, 21, 0.16), transparent 24rem),
+			linear-gradient(135deg, #07111f 0%, #0f172a 55%, #111827 100%);
+		padding: clamp(0.75rem, 2vw, 1.5rem);
+		overflow-y: auto;
+	}
+
+	.tracker-shell {
+		width: min(1640px, 100%);
+		margin: 0 auto;
+	}
+
+	.tracker-layout {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		height: auto;
+		min-height: 0;
+	}
+
+	.standard-content-grid {
+		flex: 1;
+		display: grid;
+		grid-template-columns: minmax(300px, 0.7fr) minmax(0, 1.3fr);
+		gap: clamp(1rem, 2vw, 1.6rem);
+		min-height: 0;
+		align-items: stretch;
+	}
+
+	.chipper-content-grid {
+		flex: 1;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
+		gap: 1rem;
+		min-height: 0;
+	}
+
+	.session-sidebar,
+	.session-main,
+	.chipper-overview {
+		position: relative;
+		overflow: hidden auto;
+		min-height: 0;
+		border: 1px solid rgba(226, 232, 240, 0.16);
+		border-radius: 28px;
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.66));
+		box-shadow: 0 24px 70px rgba(0, 0, 0, 0.3);
+		backdrop-filter: blur(20px);
+		padding: clamp(1.1rem, 2vw, 1.75rem);
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.session-sidebar::before,
+	.session-main::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		border-radius: inherit;
+		background: linear-gradient(
+			135deg,
+			rgba(250, 204, 21, 0.08),
+			transparent 28%,
+			rgba(56, 189, 248, 0.06)
+		);
+	}
+
+	.session-sidebar > *,
+	.session-main > * {
+		position: relative;
+		z-index: 1;
+	}
+
+	.timer-card {
+		width: 100%;
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.72));
+		border: 1px solid rgba(250, 204, 21, 0.2);
+		border-radius: 24px;
+		padding: clamp(1.25rem, 2vw, 1.75rem);
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		text-align: left;
+		box-shadow: 0 20px 55px rgba(0, 0, 0, 0.28);
+	}
+
+	.timer-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.phase-label {
+		font-family: var(--font-display);
+		font-size: 1.35rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-secondary);
+	}
+
+	.time-display {
+		font-family: var(--font-display);
+		font-size: 3.5rem;
+		color: var(--brand-yellow);
+		line-height: 1;
+	}
+
+	@media (max-width: 900px) {
+		.standard-content-grid,
+		.chipper-content-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.session-sidebar,
+		.session-main,
+		.chipper-overview {
+			max-height: none;
+		}
+	}
+
+	.phase-meta {
+		margin-top: 0.25rem;
+		display: flex;
+		gap: 0.5rem;
+		justify-content: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.phase-chip {
+		background: var(--surface-1);
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		padding: 0.2rem 0.75rem;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+	}
+
+	.station-overview,
+	.workout-overview {
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.86), rgba(30, 41, 59, 0.62));
+		border: 1px solid rgba(226, 232, 240, 0.14);
+		border-radius: 24px;
+		padding: clamp(1.25rem, 2vw, 1.7rem);
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		box-shadow: inset 0 1px rgba(255, 255, 255, 0.04);
+	}
+
+	.amrap-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	.amrap-line {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+	}
+
+	.amrap-order {
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 10px;
+		border: 1px solid var(--border-color);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		background: var(--surface-1);
+	}
+
+	.amrap-details {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.amrap-name {
+		margin: 0;
+		font-weight: 600;
+	}
+
+	.amrap-simple-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+		gap: 1.25rem;
+		align-items: stretch;
+	}
+
+	.amrap-time-card,
+	.amrap-move-card,
+	.amrap-round-card {
+		background: var(--surface-1);
+		border: 1px solid var(--border-color);
+		border-radius: 18px;
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		min-height: 100%;
+	}
+
+	.amrap-clock {
+		font-family: var(--font-display);
+		font-size: 4rem;
+		color: var(--brand-yellow);
+		margin: 0;
+	}
+
+	.amrap-move-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.8rem;
+	}
+
+	.amrap-move-list li {
+		display: flex;
+		gap: 0.75rem;
+		align-items: flex-start;
+	}
+
+	.amrap-move-details {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	.amrap-move-details strong {
+		font-size: 1.05rem;
+	}
+
+	.amrap-desc {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.amrap-round-controls {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(64px, 1fr));
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.round-step {
+		background: var(--surface-2);
+		border: 1px solid var(--border-color);
+		border-radius: 14px;
+		color: var(--text-secondary);
+		font-size: 1.8rem;
+		font-weight: 700;
+		padding: 0.6rem;
+		cursor: pointer;
+		transition:
+			transform 0.1s ease,
+			border-color 0.1s ease;
+	}
+
+	.round-step:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.round-step:not(:disabled):hover,
+	.round-step:not(:disabled):focus-visible {
+		transform: translateY(-1px);
+		border-color: var(--brand-yellow);
+		outline: none;
+	}
+
+	.amrap-round-display {
+		text-align: center;
+		font-family: var(--font-display);
+		font-size: 2.8rem;
+		color: var(--brand-yellow);
+		background: rgba(234, 179, 8, 0.08);
+		border: 1px solid rgba(234, 179, 8, 0.25);
+		border-radius: 16px;
+		padding: 0.75rem 0.5rem;
+	}
+
+	.extra-reps-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+		margin-top: 0.5rem;
+	}
+
+	.extra-reps-field input {
+		background: var(--surface-2);
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+		color: var(--text-primary);
+		padding: 0.65rem 0.75rem;
+		font-size: 1rem;
+	}
+
+	.round-hint {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+
+	.eyebrow {
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.station-heading h2,
+	.workout-overview h2 {
+		margin: 0;
+		font-size: 1.4rem;
+		color: var(--text-secondary);
+	}
+
+	.station-meta {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.workout-overview ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.workout-overview li {
+		display: flex;
+		gap: 0.75rem;
+		align-items: flex-start;
+		color: var(--text-secondary);
+	}
+
+	.workout-index {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		background: rgba(148, 163, 184, 0.2);
+		font-family: var(--font-display);
+		font-size: 0.9rem;
+		color: var(--brand-yellow);
+	}
+
+	.workout-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.workout-info strong {
+		font-size: 0.95rem;
+		color: var(--text-secondary);
+	}
+
+	.workout-info span {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.equipment-options-list {
+		margin-top: 0.75rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.equipment-options-label {
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+	}
+
+	.equipment-options-values {
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+
+	.station-next {
+		margin-top: 0.75rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.station-next h3 {
+		margin: 0;
+		font-size: 0.85rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+	}
+
+	.station-chip {
+		align-self: flex-start;
+		background: rgba(148, 163, 184, 0.18);
+		border-radius: 999px;
+		padding: 0.25rem 0.75rem;
+		font-size: 0.75rem;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--text-secondary);
+	}
+
+	.pairing-controls {
+		display: flex;
+		gap: 1rem;
+		align-items: center;
+		justify-content: space-between;
+		background: var(--surface-1);
+		border: 1px solid var(--border-color);
+		border-radius: 16px;
+		padding: 1.25rem 1.5rem;
+		text-align: left;
+	}
+
+	.pairing-copy h2 {
+		margin: 0 0 0.25rem;
+		font-size: 1.1rem;
+		color: var(--text-secondary);
+	}
+
+	.pairing-copy p {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.pairing-error {
+		margin-top: 0.5rem;
+		color: #f87171;
+		font-size: 0.85rem;
+	}
+
+	.pairing-actions {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		flex: 1;
+	}
+
+	.pairing-toggle {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(140px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.pairing-toggle button {
+		border-radius: 999px;
+		padding: 0.65rem 1rem;
+		font-weight: 700;
+		cursor: pointer;
+		border: 1px solid var(--border-color);
+		background: transparent;
+		color: var(--text-secondary);
+		transition:
+			background-color 0.2s ease,
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	.pairing-toggle button.active {
+		background: var(--brand-yellow);
+		border-color: var(--brand-yellow);
+		color: var(--deep-space);
+	}
+
+	.pairing-toggle button.locked {
+		border-style: dashed;
+	}
+
+	.pairing-toggle button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.pairing-status {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+
+	.pairing-note {
+		margin: -0.35rem 0 0;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.chipper-overview {
+		text-align: left;
+	}
+
+	.chipper-header h2 {
+		margin: 0;
+		font-size: 1.4rem;
+		color: var(--text-secondary);
+	}
+
+	.chipper-header p {
+		margin: 0.35rem 0 0;
+		color: var(--text-muted);
+	}
+
+	.chipper-pyramid {
+		display: grid;
+		gap: 1rem;
+	}
+
+	.chipper-tier {
+		display: grid;
+		grid-template-columns: 80px 1fr;
+		gap: 1rem;
+		align-items: start;
+	}
+
+	.tier-reps {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 68px;
+		height: 68px;
+		border-radius: 14px;
+		background: var(--surface-2, rgba(255, 255, 255, 0.04));
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		font-family: var(--font-display);
+		font-size: 1.4rem;
+		color: var(--brand-yellow);
+	}
+
+	.tier-movements {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 0.45rem;
+	}
+
+	.tier-movements li {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+		color: var(--text-primary);
+		font-size: 0.95rem;
+	}
+
+	.tier-item {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		cursor: pointer;
+	}
+
+	.tier-checkbox {
+		margin-left: auto;
+		width: 1.05rem;
+		height: 1.05rem;
+		accent-color: var(--brand-yellow);
+		cursor: pointer;
+	}
+
+	.tier-movements li.completed .tier-name {
+		text-decoration: line-through;
+		color: var(--text-muted);
+	}
+
+	.tier-movements li.completed .tier-category {
+		opacity: 0.6;
+	}
+
+	.tier-movements li.completed .tier-order {
+		color: var(--text-muted);
+		opacity: 0.6;
+	}
+
+	.tier-order {
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+
+	.tier-category {
+		background: rgba(255, 255, 255, 0.08);
+		border-radius: 999px;
+		padding: 0.1rem 0.6rem;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.chipper-empty {
+		margin: 0;
+		color: var(--text-muted);
+		font-style: italic;
+	}
+
+	.chipper-finisher-card {
+		display: grid;
+		grid-template-columns: 90px 1fr;
+		gap: 1rem;
+		align-items: start;
+		padding-top: 1rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.08);
+	}
+
+	.finisher-label {
+		font-size: 0.85rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+	}
+
+	.finisher-details {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		color: var(--text-muted);
+	}
+
+	.finisher-details strong {
+		color: var(--text-secondary);
+		font-size: 1rem;
+	}
+
+	@media (max-width: 720px) {
+		.chipper-tier {
+			grid-template-columns: 1fr;
+		}
+
+		.tier-reps {
+			width: 54px;
+			height: 54px;
+			font-size: 1.1rem;
+		}
+
+		.chipper-finisher-card {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.pairing-summary {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		background: var(--surface-1);
+		border: 1px solid var(--border-color);
+		border-radius: 16px;
+		padding: 1.25rem 1.5rem;
+		text-align: left;
+	}
+
+	.summary-row {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		align-items: center;
+	}
+
+	.summary-chip {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 999px;
+		padding: 0.25rem 0.75rem;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		border: 1px solid transparent;
+	}
+
+	.summary-chip.solo {
+		background: rgba(59, 130, 246, 0.16);
+		border-color: rgba(59, 130, 246, 0.35);
+		color: #60a5fa;
+	}
+
+	.summary-chip.partner {
+		background: rgba(34, 197, 94, 0.16);
+		border-color: rgba(34, 197, 94, 0.35);
+		color: #34d399;
+	}
+
+	.summary-chip.role {
+		background: rgba(253, 224, 71, 0.16);
+		border-color: rgba(253, 224, 71, 0.35);
+		color: var(--brand-yellow);
+	}
+
+	.summary-chip.locked {
+		background: rgba(148, 163, 184, 0.12);
+		border-color: rgba(148, 163, 184, 0.3);
+		color: var(--text-muted);
+	}
+
+	.btn {
+		border-radius: 999px;
+		padding: 0.65rem 1.5rem;
+		font-weight: 700;
+		cursor: pointer;
+		border: none;
+		transition:
+			transform 140ms ease,
+			box-shadow 140ms ease;
+		font-size: 1rem;
+	}
+
+	.btn:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+		transform: none;
+		box-shadow: none;
+	}
+
+	.btn-primary {
+		background: var(--brand-green);
+		color: var(--text-primary);
+		box-shadow: 0 12px 30px -18px rgba(22, 163, 74, 0.9);
+	}
+
+	.btn-primary:not(:disabled):hover {
+		transform: translateY(-2px);
+		box-shadow: 0 18px 40px -16px rgba(22, 163, 74, 0.9);
+	}
+
+	.btn-outline {
+		background: transparent;
+		border: 1px solid var(--border-color);
+		color: var(--text-secondary);
+	}
+
+	.btn-outline:not(:disabled):hover {
+		transform: translateY(-2px);
+		box-shadow: 0 12px 24px -18px rgba(148, 163, 184, 0.6);
+	}
+
+	.btn-save {
+		margin-top: 1rem;
+		width: 100%;
+		min-height: 3.4rem;
+		border-radius: 18px;
+		background: linear-gradient(135deg, var(--brand-green), #86efac);
+		color: #052e16;
+		box-shadow: 0 18px 36px -20px rgba(22, 163, 74, 0.9);
+		font-weight: 900;
+	}
+
+	.btn-save:not(:disabled):hover {
+		transform: translateY(-2px);
+		box-shadow: 0 22px 45px -18px rgba(22, 163, 74, 0.9);
+	}
+
+	.score-card {
+		background: linear-gradient(145deg, rgba(15, 23, 42, 0.88), rgba(30, 41, 59, 0.74));
+		width: 100%;
+		padding: clamp(1.25rem, 3vw, 2rem);
+		border-radius: 28px;
+		border: 1px solid rgba(226, 232, 240, 0.18);
+		text-align: left;
+		box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+	}
+
+	.score-rest-banner {
+		background: rgba(148, 163, 184, 0.14);
+		border: 1px solid rgba(148, 163, 184, 0.25);
+		border-radius: 14px;
+		padding: 0.75rem 1rem;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+
+	.score-equipment-selector {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+	}
+
+	.selector-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.selector-label {
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+	}
+
+	.clear-selection {
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		cursor: pointer;
+		padding: 0.15rem 0.35rem;
+	}
+
+	.clear-selection:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.score-card.placeholder {
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		background: rgba(15, 23, 42, 0.6);
+		border-style: dashed;
+		box-shadow: none;
+		min-height: 200px;
+	}
+
+	.placeholder-clock {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.clock-label {
+		font-size: 0.85rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-secondary);
+	}
+
+	.clock-time {
+		font-family: var(--font-display);
+		font-size: clamp(2.8rem, 3vw + 1rem, 3.6rem);
+		font-weight: 600;
+		color: var(--brand-yellow);
+	}
+
+	.score-card.placeholder h2 {
+		margin: 0 0 0.5rem;
+		font-size: 1.4rem;
+		color: var(--text-secondary);
+	}
+
+	.score-card.placeholder p {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+	}
+
+	.score-header {
+		display: grid;
+		grid-template-columns: minmax(220px, 0.85fr) minmax(260px, 1fr);
+		gap: clamp(1rem, 2vw, 1.5rem);
+		align-items: start;
+	}
+
+	.score-header h2 {
+		margin: 0.1rem 0 0.15rem;
+		font-size: clamp(2.15rem, 4vw, 3.2rem);
+		line-height: 0.95;
+	}
+
+	.score-eyebrow {
+		font-size: 0.78rem;
+		font-weight: 900;
+		letter-spacing: 0.16em;
+		text-transform: uppercase;
+		color: #93c5fd;
+	}
+
+	.score-subtitle {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+	}
+
+	.score-helper {
+		margin: 1rem 0 0;
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		line-height: 1.4;
+	}
+
+	.score-meta {
+		margin-top: 0;
+		display: flex;
+		gap: 0.5rem;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+		align-items: center;
+	}
+
+	.score-chip {
+		background: rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		padding: 0.3rem 0.75rem;
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-secondary);
+	}
+
+	.score-chip.emphasis {
+		background: rgba(253, 224, 71, 0.16);
+		border-color: rgba(253, 224, 71, 0.45);
+		color: var(--brand-yellow);
+	}
+
+	.score-chip.subtle {
+		background: rgba(148, 163, 184, 0.12);
+		border-color: rgba(148, 163, 184, 0.3);
+		color: var(--text-muted);
+	}
+
+	.input-grid {
+		margin-top: 0.25rem;
+		display: grid;
+		gap: 1rem;
+	}
+
+	.input-grid.two-column {
+		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+	}
+
+	.input-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.input-field.full {
+		grid-column: 1 / -1;
+	}
+
+	.score-card label,
+	.equipment-select label {
+		display: grid;
+		gap: 0.55rem;
+		color: var(--text-primary);
+		font-size: 0.95rem;
+		font-weight: 800;
+	}
+
+	.score-card label > span,
+	.equipment-select label > span {
+		color: #bfdbfe;
+		font-size: 0.78rem;
+		font-weight: 900;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.score-card input,
+	.score-card select,
+	.score-card textarea {
+		width: 100%;
+		border: 1px solid rgba(226, 232, 240, 0.16);
+		border-radius: 18px;
+		background: rgba(2, 6, 23, 0.62);
+		color: var(--text-primary);
+		padding: 0.95rem 1rem;
+		min-height: 3.35rem;
+		font-size: 1.05rem;
+		box-shadow: inset 0 1px rgba(255, 255, 255, 0.04);
+		transition:
+			border-color var(--transition),
+			box-shadow var(--transition),
+			background var(--transition);
+	}
+
+	.score-card input::placeholder,
+	.score-card textarea::placeholder {
+		color: rgba(203, 213, 225, 0.58);
+	}
+
+	.score-card input:focus,
+	.score-card select:focus,
+	.score-card textarea:focus {
+		border-color: rgba(250, 204, 21, 0.62);
+		outline: none;
+		background: rgba(2, 6, 23, 0.82);
+		box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.13);
+	}
+
+	.score-card textarea {
+		min-height: 8.2rem;
+		resize: vertical;
+	}
+
+	.equipment-select {
+		width: 100%;
+	}
+
+	.equipment-select select {
+		min-height: 3.35rem;
+		border-radius: 18px;
+	}
+
+	.actions-row {
+		margin-top: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		align-items: stretch;
+	}
+
+	.actions-row .btn-save {
+		margin-top: 0;
+	}
+
+	.actions-row .save-feedback {
+		margin: 0;
+		text-align: center;
+	}
+
+	.save-feedback {
+		font-size: 0.85rem;
+	}
+
+	.save-feedback.success {
+		color: var(--brand-green);
+	}
+
+	.save-feedback.error {
+		color: #f87171;
+	}
+
+	.save-feedback.auto {
+		color: var(--text-secondary);
+	}
+
+	.save-feedback.info {
+		color: var(--text-muted);
+	}
+
+	.totals {
+		margin-top: 1.5rem;
+		text-align: left;
+		background: rgba(15, 23, 42, 0.65);
+		border: 1px solid var(--border-color);
+		border-radius: 14px;
+		padding: 1.1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.totals h3 {
+		margin: 0;
+		font-size: 0.95rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-secondary);
+	}
+
+	.totals ul {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.totals li {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 0.75rem;
+		color: var(--text-primary);
+		font-size: 0.95rem;
+	}
+
+	.totals li span:first-child {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
+	.totals li span:last-child {
+		font-weight: 600;
+		font-size: 0.95rem;
+		text-align: right;
+	}
+
+	.notes-total span:last-child {
+		white-space: pre-wrap;
+		font-family: var(--font-body);
+		font-size: 0.85rem;
+		font-weight: 400;
+	}
+
+	.start-callout {
+		margin: 0 0 0.75rem;
+		padding: 0.75rem;
+		border-radius: 12px;
+		background: rgba(56, 189, 248, 0.08);
+		border: 1px solid rgba(56, 189, 248, 0.25);
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+	.start-callout strong {
+		color: var(--brand-yellow);
+	}
+	.rest-callout {
+		margin: 0.75rem 0;
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		background: rgba(148, 163, 184, 0.12);
+		border: 1px solid rgba(148, 163, 184, 0.25);
+		color: var(--text-secondary);
+		font-size: 0.95rem;
+		line-height: 1.5;
+	}
+	.rest-callout strong {
+		color: var(--text-primary);
+	}
+	.start-role {
+		display: inline-block;
+		margin-right: 0.5rem;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		background: rgba(253, 224, 71, 0.18);
+		color: var(--brand-yellow);
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.12em;
+	}
+
+	.upcoming-note {
+		margin: -0.25rem 0 0.25rem;
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	.upcoming-note strong {
+		color: var(--text-secondary);
+	}
+
+	.station-heading {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.station-eyebrow {
+		font-size: 0.75rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--text-muted);
+	}
+
+	.station-heading h2 {
+		margin: 0;
+		font-size: 1.4rem;
+		color: var(--text-secondary);
+	}
+
+	.station-meta {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+		display: flex;
+		gap: 0.35rem;
+		align-items: center;
+	}
+
+	.station-meta span[aria-hidden='true'] {
+		color: var(--text-muted);
+	}
+
+	.task-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.task-line {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		font-size: 0.95rem;
+	}
+
+	.task-label {
+		width: 22px;
+		height: 22px;
+		border-radius: 50%;
+		font-size: 0.6rem;
+		flex-shrink: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.task-content {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		align-items: flex-start;
+	}
+
+	.task-text {
+		color: var(--text-primary);
+		font-size: 1rem;
+		font-weight: 500;
+	}
+
+	.task-chip {
+		background: rgba(148, 163, 184, 0.12);
+		border: 1px solid rgba(148, 163, 184, 0.3);
+		border-radius: 999px;
+		padding: 0.2rem 0.65rem;
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-muted);
+	}
+	.task-label.p1 {
+		background: #34d39933;
+		color: #34d399;
+	}
+
+	.task-label.p2 {
+		background: #f472b633;
+		color: #f472b6;
+	}
+
+	.post-workout-card {
+		background: var(--surface-1);
+		border: 1px solid var(--border-color);
+		border-radius: 16px;
+		padding: 1.5rem;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.post-workout-card h2 {
+		margin-bottom: 0.5rem;
+		font-size: 1.4rem;
+		color: var(--text-secondary);
+	}
+
+	.post-workout-card p {
+		margin: 0.5rem 0 1rem;
+		color: var(--text-muted);
+	}
+
+	.completion-summary {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		background: rgba(15, 23, 42, 0.55);
+		border: 1px solid var(--border-color);
+		border-radius: 12px;
+		padding: 1rem;
+		text-align: left;
+	}
+
+	.summary-line {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		font-size: 0.95rem;
+		color: var(--text-secondary);
+	}
+
+	.summary-line span:first-child {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.completion-hint {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.9rem;
+	}
+
+	.post-workout-card .status {
+		margin-top: 0.75rem;
+		font-size: 0.9rem;
+	}
+
+	.post-workout-card .status.success {
+		color: var(--brand-green);
+	}
+
+	.post-workout-card .status.error {
+		color: #f87171;
+	}
+
+	.post-workout-card .status.warning {
+		color: var(--brand-yellow);
+	}
+
+	.completion-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(15, 23, 42, 0.75);
+		backdrop-filter: blur(6px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1.5rem;
+		z-index: 1100;
+	}
+
+	.completion-card {
+		background: var(--bg-panel);
+		border: 1px solid var(--border-color);
+		border-radius: 18px;
+		padding: 1.75rem;
+		width: 100%;
+		max-width: 420px;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		box-shadow: 0 26px 65px rgba(15, 23, 42, 0.55);
+	}
+
+	.completion-card h3 {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: 1.8rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--brand-yellow);
+	}
+
+	.modal-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		text-align: left;
+	}
+
+	.modal-field span {
+		font-size: 0.85rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+	}
+
+	.modal-field input,
+	.modal-field select {
+		border-radius: 12px;
+		border: 1px solid var(--border-color);
+		background: var(--deep-space);
+		color: var(--text-primary);
+		padding: 0.55rem 0.75rem;
+		font-size: 1rem;
+	}
+
+	.modal-grid {
+		display: grid;
+		gap: 0.75rem;
+		grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+	}
+
+	.modal-checkbox {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+
+	.modal-checkbox input {
+		width: 18px;
+		height: 18px;
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75rem;
+	}
+
+	.completion-error {
+		color: #f87171;
+		font-size: 0.9rem;
+		margin: 0;
+	}
+
+	.feedback-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(15, 23, 42, 0.75);
+		backdrop-filter: blur(6px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1.5rem;
+		z-index: 1200;
+	}
+
+	.feedback-card {
+		background: var(--bg-panel);
+		border: 1px solid var(--border-color);
+		border-radius: 20px;
+		padding: 2rem;
+		width: 100%;
+		max-width: 420px;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		box-shadow: 0 30px 70px rgba(15, 23, 42, 0.45);
+	}
+
+	.feedback-card h3 {
+		margin: 0;
+		font-family: var(--font-display);
+		letter-spacing: 0.08em;
+		color: var(--brand-yellow);
+		font-size: 2.1rem;
+		text-transform: uppercase;
+	}
+
+	.feedback-card p {
+		margin: 0;
+		color: var(--text-secondary);
+	}
+
+	.upload-recap {
+		border: 1px solid var(--border-color);
+		border-radius: 14px;
+		padding: 0.85rem 1rem;
+		background: rgba(15, 23, 42, 0.45);
+		display: grid;
+		gap: 0.3rem;
+	}
+
+	.upload-recap-label {
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.upload-recap-line {
+		margin: 0;
+		color: var(--text-secondary);
+	}
+
+	.feedback-stars {
+		display: flex;
+		gap: 0.5rem;
+		justify-content: center;
+	}
+
+	.star-button {
+		background: transparent;
+		border: none;
+		color: rgba(148, 163, 184, 0.6);
+		font-size: 2.25rem;
+		cursor: pointer;
+		transition:
+			transform var(--transition),
+			color var(--transition);
+	}
+
+	.star-button.active,
+	.star-button:hover,
+	.star-button:focus-visible {
+		color: var(--brand-yellow);
+		transform: scale(1.05);
+		outline: none;
+	}
+
+	.feedback-card textarea {
+		background: var(--deep-space);
+		border: 1px solid var(--border-color);
+		border-radius: 14px;
+		color: var(--text-primary);
+		padding: 0.85rem 1rem;
+		min-height: 120px;
+		resize: vertical;
+		font-family: inherit;
+	}
+
+	.feedback-card textarea::placeholder {
+		color: rgba(148, 163, 184, 0.7);
+	}
+
+	.feedback-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		justify-content: flex-end;
+	}
+
+	.feedback-actions .btn {
+		flex: 1;
+		min-width: 140px;
+	}
+
+	.btn.ghost {
+		background: transparent;
+		border: 1px solid var(--border-color);
+		color: var(--text-secondary);
+	}
+
+	.btn.ghost:not(:disabled):hover,
+	.btn.ghost:focus-visible {
+		color: var(--text-primary);
+		border-color: var(--text-secondary);
+	}
+
+	@media (max-width: 640px) {
+		.tracker-container {
+			padding: 1rem;
+		}
+
+		.session-sidebar,
+		.session-main {
+			padding: 1.25rem;
+		}
+
+		.pairing-controls {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.pairing-actions {
+			width: 100%;
+		}
+
+		.pairing-toggle {
+			grid-template-columns: 1fr;
+		}
+
+		.pairing-toggle button {
+			width: 100%;
+		}
+
+		.btn {
+			width: 100%;
+			justify-content: center;
+		}
+
+		.score-header {
+			grid-template-columns: 1fr;
+		}
+
+		.score-card {
+			padding: 1.25rem;
+		}
+	}
 </style>


### PR DESCRIPTION
### Motivation
- Improve readability and visual hierarchy on the live timer page so athletes/coaches can scan timer and score inputs quickly. 
- Modernise the member dashboard and admin session/workout builder to feel current and client-ready while preserving the app's core session flow. 
- Make score entry, library modal and create-workout flows clearer and easier to use for coaches when creating sessions. 

### Description
- Restyled the live timer into a centered shell and split layout (`tracker-shell` + layout tweaks) and refreshed the score entry card with clearer label elements, dark themed inputs, elevated panels and a stronger save CTA; adjusted markup to improve scanning and a11y (e.g., label spans for inputs). (file: `src/routes/live/[sessionId]/+page.svelte`) 
- Updated dashboard hero and metric cards into a compact next-class panel with refreshed gradients, modern cards and a coach-focused hero. (file: `src/routes/dashboard/+page.svelte`) 
- Overhauled admin sessions planner to include a coach overview, session stats, quick-schedule panel and more modern responsive cards. (file: `src/routes/admin/sessions/+page.svelte`) 
- Polished the workout builder UI: larger builder canvas, clearer hero, improved field/fieldset styling, refined station/editor cards and an improved exercise-library modal. (file: `src/routes/admin/create/+page.svelte`) 
- Large CSS/CSS-layout adjustments across the above pages: updated card radii, gradients, shadows, input styles, button treatments and responsive grid breakpoints. 
- Kept all existing business logic intact (roster/score upload/completion flow) and avoided functional changes to core session processes. 

### Testing
- Ran `npm --prefix workout-app run check` (`svelte-check`) and received no Svelte diagnostics after the changes (success). 
- Ran `prettier` and formatted affected files (success). 
- Ran `npm --prefix workout-app run build`; Vite SSR reached rendering but the build failed in this environment due to Firebase configuration during SSR (`auth/invalid-api-key`) and not due to UI code changes (failure due to environment). 
- Ran `npm --prefix workout-app run lint`; linting failed with existing repo-wide issues (many Svelte lint rules / keyed-each and reactivity warnings) unrelated to the visual polish (repo has pre-existing lint debt). 
- Attempted a Playwright screenshot of the admin sessions page; browsers and host deps were installed and a screenshot was captured (`/tmp/circuits-sessions.png`), but the local app render in this environment shows the Firebase auth overlay (environment issue) rather than a fully-authenticated app UI (partial success with environmental caveat).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0238c6cdfc832faa005d3669b8702d)